### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
 SimpleDirectMediaLayer = "0.3, 0.4"
-CImGui = "1"
+CImGui = "~1.82"
 ImGuiGLFWBackend = "0.1.2"
 ImGuiOpenGLBackend = "0.1.1"
 JSON3 = "1"


### PR DESCRIPTION
CImGui major/minor versions follow upstream ImGui, so minor version updates may be breaking. This only allows patch updates.

(making the PR because there's a new breaking release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0)