### PR TITLE
[29] Scene switching in game mode

### DIFF
--- a/src/Component/Collider.jl
+++ b/src/Component/Collider.jl
@@ -99,7 +99,7 @@ module ColliderModule
                         if collision[1] == Top::CollisionDirection
                             push!(this.currentCollisions, collider)
                             for eventToCall in this.collisionEvents
-                                eventToCall()
+                                eventToCall(collider)
                             end
                             #Begin to overlap, correct position
                             transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y + collision[2]))
@@ -107,7 +107,7 @@ module ColliderModule
                         if collision[1] == Left::CollisionDirection
                             push!(this.currentCollisions, collider)
                             for eventToCall in this.collisionEvents
-                                eventToCall()
+                                eventToCall(collider)
                             end
                             #Begin to overlap, correct position
                             transform.setPosition(Math.Vector2f(transform.getPosition().x + collision[2], transform.getPosition().y))
@@ -115,7 +115,7 @@ module ColliderModule
                         if collision[1] == Right::CollisionDirection
                             push!(this.currentCollisions, collider)
                             for eventToCall in this.collisionEvents
-                                eventToCall()
+                                eventToCall(collider)
                             end
                             #Begin to overlap, correct position
                             transform.setPosition(Math.Vector2f(transform.getPosition().x - collision[2], transform.getPosition().y))
@@ -126,7 +126,11 @@ module ColliderModule
                                 push!(this.currentRests, collider)
                             end
                             for eventToCall in this.collisionEvents
-                                eventToCall()
+                                try
+                                    eventToCall(collider)
+                                catch e
+                                    println(e)
+                                end
                             end
                             #Begin to overlap, correct position
                             transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y - collision[2]))
@@ -137,7 +141,7 @@ module ColliderModule
                         if collision[1] == Below::ColliderLocation
                             push!(this.currentCollisions, collider)
                             for eventToCall in this.collisionEvents
-                                eventToCall()
+                                eventToCall(collider)
                             end
                         end
                     end

--- a/src/Component/Sprite.jl
+++ b/src/Component/Sprite.jl
@@ -59,12 +59,10 @@
     function Base.getproperty(this::Sprite, s::Symbol)
         if s == :draw
             function()
-                if this.image == C_NULL
+                if this.image == C_NULL || MAIN.renderer == C_NULL
                     return
                 end
-                if MAIN.renderer == C_NULL #|| this.renderer == Ptr{nothing}
-                    return                    
-                end
+
                 if this.texture == C_NULL
                     this.texture = SDL2.SDL_CreateTextureFromSurface(MAIN.renderer, this.image)
                     this.setColor()
@@ -142,6 +140,17 @@
                 this.imagePath = imagePath
                 this.texture = SDL2.SDL_CreateTextureFromSurface(this.renderer, this.image)
                 this.setColor()
+            end
+        elseif s == :destroy
+            function()
+                if this.image == C_NULL
+                    return
+                end
+
+                SDL2.SDL_DestroyTexture(this.texture)
+                SDL2.SDL_FreeSurface(this.image)
+                this.image = C_NULL
+                this.texture = C_NULL
             end
         elseif s == :setColor
             function ()

--- a/src/Entity.jl
+++ b/src/Entity.jl
@@ -16,8 +16,9 @@ module EntityModule
         components::Array{Any}
         isActive::Bool
         name::String
+        persistentBetweenScenes::Bool
         scripts::Array{Any}
-        #
+        
         function Entity(name::String = "New entity", transform::Union{Ptr{Nothing}, Transform} = C_NULL, components::Array{Union{Animation, Animator, Collider, CircleCollider, Rigidbody, Shape, SoundSource, Sprite}} = Vector{Union{Animation, Animator, Collider, CircleCollider, Rigidbody, Shape, SoundSource, Sprite}}(), scripts::Array = [])
             this = new()
 
@@ -36,6 +37,7 @@ module EntityModule
             for script in scripts
                 this.addScript(script)
             end
+            this.persistentBetweenScenes = false
 
             return this
         end

--- a/src/JulGame.jl
+++ b/src/JulGame.jl
@@ -1,6 +1,11 @@
 module JulGame
     using SimpleDirectMediaLayer
     const SDL2 = SimpleDirectMediaLayer
+
+    function __init__()
+        SDL2.init()
+    end
+
     include("ModuleExtensions/SDL2Extension.jl")
     const SDL2E = SDL2Extension
     export SDL2, SDL2E

--- a/src/Macros.jl
+++ b/src/Macros.jl
@@ -3,4 +3,9 @@ module Macros
     macro event(expr)
         esc(:(()->($expr)))
     end
+
+    export @argevent
+    macro argevent(args, expr)
+        esc(:(($args)->($expr)))
+    end
 end

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -76,6 +76,15 @@ module MainLoop
 					return
 				end
 			end
+		elseif s == :changeScene
+			function()
+				InitializeScriptsAndComponents(this, false)
+
+				if !isUsingEditor
+					this.fullLoop()
+					return
+				end
+			end
 		elseif s == :fullLoop
 			function ()
 				try
@@ -347,18 +356,42 @@ function InitializeScriptsAndComponents(this::Main, isUsingEditor::Bool = false)
 end
 
 export ChangeScene
-function ChangeScene(this::Main)
+function ChangeScene(sceneFileName::String)
 	#destroy current scene 
-	
+	for entity in MAIN.scene.entities
+		for script in entity.scripts
+			try
+				script.onShutDown()
+			catch e
+				if typeof(e) != ErrorException || !contains(e.msg, "onShutDown")
+					println("Error shutting down script")
+					println(e)
+					Base.show_backtrace(stdout, catch_backtrace())
+				end
+			end
+		end
+		DestroyEntity(entity)
+	end
+
+	#delete all textboxes
+	# for textBox in MAIN.scene.textBoxes
+	# 	textBox.destroy()
+	# 	delete!(MAIN.scene.textBoxes, textBox)
+	# end
+
+	# #delete all screen buttons
+	# for screenButton in MAIN.scene.screenButtons
+	# 	screenButton.destroy()
+	# 	delete!(MAIN.scene.screenButtons, screenButton)
+	# end
 
 	#load new scene 
-	this.scene = Scene()
-	this.level.scene = sceneFileName
-	this.level.changeScene()
+	MAIN.scene = Scene()
+	MAIN.level.scene = sceneFileName
+	MAIN.level.changeScene()
 	spriteLayers::Dict
 
-	InitializeScriptsAndComponents(this)
-
+	InitializeScriptsAndComponents(MAIN)
 end
 
 """

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -69,7 +69,6 @@ module MainLoop
 		if s == :init
 			function(isUsingEditor = false, dimensions = C_NULL, isResizable::Bool = false, autoScaleZoom::Bool = true)
 
-				SDL2.init()
 				if dimensions == Math.Vector2()
 					displayMode = SDL2.SDL_DisplayMode[SDL2.SDL_DisplayMode(0x12345678, 800, 600, 60, C_NULL)]
 					SDL2.SDL_GetCurrentDisplayMode(0, pointer(displayMode))
@@ -97,7 +96,7 @@ module MainLoop
 				SDL2.SDL_RenderSetScale(this.renderer, this.zoom, this.zoom)
 				this.font = SDL2.TTF_OpenFont(joinpath(this.assets, "fonts", "FiraCode", "ttf", "FiraCode-Regular.ttf"), 50)
 
-				InitializeScriptsAndComponents(this)
+				InitializeScriptsAndComponents(this, isUsingEditor)
 
 				if !isUsingEditor
 					this.fullLoop()
@@ -310,7 +309,7 @@ module MainLoop
 		end
 	end
 
-function InitializeScriptsAndComponents(this::Main)
+function InitializeScriptsAndComponents(this::Main, isUsingEditor::Bool = false)
 	scripts = []
 	for entity in this.scene.entities
 		for script in entity.scripts

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -515,7 +515,12 @@ function GameLoop(this, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysicsTime
 					return
 				end
 				for rigidbody in this.scene.rigidbodies
-					rigidbody.update(deltaTime)
+					try
+						rigidbody.update(deltaTime)
+					catch e
+						println(rigidbody.parent.name, " with id: ", rigidbody.parent.id, " has a problem with it's rigidbody")
+						throw(e)
+					end
 				end
 				lastPhysicsTime[] =  currentPhysicsTime
 			end
@@ -534,7 +539,12 @@ function GameLoop(this, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysicsTime
 				end
 
 				if !isEditor
-					entity.update(deltaTime)
+					try
+						entity.update(deltaTime)
+					catch e
+						println(entity.name, " with id: ", entity.id, " has a problem with it's update")
+						throw(e)
+					end
 					entityAnimator = entity.getAnimator()
 					if entityAnimator != C_NULL
 						entityAnimator.update(currentRenderTime, deltaTime)
@@ -560,7 +570,12 @@ function GameLoop(this, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysicsTime
 							continue
 						end
 						rendercount += 1
-						sprite.draw()
+						try
+							sprite.draw()
+						catch e
+							println(sprite.parent.name, " with id: ", sprite.parent.id, " has a problem with it's sprite")
+							throw(e)
+						end
 					end
 				end
 				#println("Skipped $skipcount, rendered $rendercount")
@@ -575,7 +590,12 @@ function GameLoop(this, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysicsTime
 				if isEditor
 					entitySprite = entity.getSprite()
 					if entitySprite != C_NULL
-						entitySprite.draw()
+						try
+							entitySprite.draw()
+						catch e
+							println(entity.name, " with id: ", entity.id, " has an error in its sprite")
+							throw(e)
+						end
 					end
 				end
 

--- a/src/Math/Vector2.jl
+++ b/src/Math/Vector2.jl
@@ -6,7 +6,6 @@ struct Vector2
     Vector2(value::Number) = new(convert(Integer, round(value)), convert(Integer, round(value)))
 
     Vector2(x::Integer, y::Integer) = new(x,y)
-    Vector2(x::Integer, y::Integer) = new(convert(Integer, x), convert(Integer, y))
 
     #convert if float
     Vector2(x::Float64, y::Float64) = new(convert(Integer,round(x)),convert(Integer,round(y)));

--- a/src/Scene.jl
+++ b/src/Scene.jl
@@ -4,7 +4,6 @@
     entities
     rigidbodies
     screenButtons
-    sounds
     textBoxes
 
     function Scene()
@@ -15,7 +14,6 @@
         this.entities = []
         this.rigidbodies = []
         this.screenButtons = []
-        this.sounds = []
         this.textBoxes = []
 
         return this

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -134,8 +134,8 @@ module SceneBuilderModule
                 end
             elseif s == :changeScene
                 function()
-                    main = MAIN
-                    scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
+                    main = this.main
+                    scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), false)
                     main.scene.entities = scene[1]
                     main.scene.textBoxes = scene[2]
 
@@ -154,7 +154,7 @@ module SceneBuilderModule
                             end
                         end
 
-                        if !isUsingEditor
+                        if true # !isUsingEditor
                             scriptCounter = 1
                             for script in entity.scripts
                                 params = []
@@ -175,7 +175,8 @@ module SceneBuilderModule
 
                                 newScript = C_NULL
                                 try
-                                    newScript = TestScript == C_NULL ? eval(Symbol(script.name))(params...) : TestScript()
+                                    newScript = eval(Symbol(script.name))(params...)
+                                    # TestScript == C_NULL ? eval(Symbol(script.name))(params...) : TestScript()
                                 catch e
                                     println(e)
                                     Base.show_backtrace(stdout, catch_backtrace())
@@ -188,7 +189,7 @@ module SceneBuilderModule
                         end
                     end
 
-                    main.init(isUsingEditor, dimensions, isResizable, autoScaleZoom)
+                    main.changeScene()
 
                     this.main = main
                         

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -132,7 +132,14 @@ module SceneBuilderModule
             elseif s == :changeScene
                 function()
                     scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), false)
-                    MAIN.scene.entities = scene[1]
+                    
+                    println("Changing scene to $this.scene")
+                    println("Entities in main scene: ", length(MAIN.scene.entities))
+
+                    for entity in scene[1]
+                        push!(MAIN.scene.entities, entity)
+                    end
+
                     MAIN.scene.textBoxes = scene[2]
 
                     for textBox in MAIN.scene.textBoxes
@@ -142,6 +149,10 @@ module SceneBuilderModule
                     end
 
                     for entity in MAIN.scene.entities
+                        if entity.persistentBetweenScenes
+                            continue
+                        end
+                        
                         for component in entity.components
                             if typeof(component) == Rigidbody
                                 push!(MAIN.scene.rigidbodies, component)

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -7,27 +7,28 @@ module SceneBuilderModule
     using ..SceneManagement.JulGame.TextBoxModule
     using ..SceneManagement.SceneReaderModule
 
-    if isdir(joinpath(pwd(), "..", "scripts")) #dev builds
-        println("Loading scripts...")
-        include.(filter(contains(r".jl$"), readdir(joinpath(pwd(), "..", "scripts"); join=true)))
-    else
-        script_folder_name = "scripts"
-        current_dir = pwd()
-
-        # Find all folders in the current directory
-        folders = filter(isdir, readdir(current_dir))
-
-        # Check each folder for the "scripts" subfolder
-        for folder in folders
-            scripts_path = joinpath(current_dir, folder, script_folder_name)
-            if isdir(scripts_path)
-                println("Loading scripts in $scripts_path...")
-                include.(filter(contains(r".jl$"), readdir(scripts_path; join=true)))
-                break  # Exit loop if "scripts" folder is found in any parent folder
+    function __init__()
+        if isdir(joinpath(pwd(), "..", "scripts")) #dev builds
+            println("Loading scripts...")
+            include.(filter(contains(r".jl$"), readdir(joinpath(pwd(), "..", "scripts"); join=true)))
+        else
+            script_folder_name = "scripts"
+            current_dir = pwd()
+            
+            # Find all folders in the current directory
+            folders = filter(isdir, readdir(current_dir))
+            
+            # Check each folder for the "scripts" subfolder
+            for folder in folders
+                scripts_path = joinpath(current_dir, folder, script_folder_name)
+                if isdir(scripts_path)
+                    println("Loading scripts in $scripts_path...")
+                    include.(filter(contains(r".jl$"), readdir(scripts_path; join=true)))
+                    break  # Exit loop if "scripts" folder is found in any parent folder
+                end
             end
         end
     end
-
         
     include("../Camera.jl")
     include("../Main.jl")

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -35,7 +35,6 @@ module SceneBuilderModule
     
     export Scene
     mutable struct Scene
-        main
         scene
         srcPath
 
@@ -57,37 +56,36 @@ module SceneBuilderModule
                         zoom = 1.0
                     end
 
-                    main = MAIN
-                    main.windowName = windowName
-                    main.zoom = zoom
-                    main.globals = globals
-                    main.level = this
-                    main.targetFrameRate = targetFrameRate
+                    MAIN.windowName = windowName
+                    MAIN.zoom = zoom
+                    MAIN.globals = globals
+                    MAIN.level = this
+                    MAIN.targetFrameRate = targetFrameRate
                     scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
-                    main.scene.entities = scene[1]
-                    main.scene.textBoxes = scene[2]
+                    MAIN.scene.entities = scene[1]
+                    MAIN.scene.textBoxes = scene[2]
                     if dimensions.x < camDimensions.x && dimensions.x > 0
                         camDimensions = Vector2(dimensions.x, camDimensions.y)
                     end
                     if dimensions.y < camDimensions.y && dimensions.y > 0
                         camDimensions = Vector2(camDimensions.x, dimensions.y)
                     end
-                    main.scene.camera = Camera(camDimensions, Vector2f(),Vector2f(), C_NULL)
-
-                    for textBox in main.scene.textBoxes
+                    MAIN.scene.camera = Camera(camDimensions, Vector2f(),Vector2f(), C_NULL)
+                    
+                    for textBox in MAIN.scene.textBoxes
                         if textBox.isWorldEntity
                             textBox.centerText()
                         end
                     end
 
-                    main.scene.rigidbodies = []
-                    main.scene.colliders = []
-                    for entity in main.scene.entities
+                    MAIN.scene.rigidbodies = []
+                    MAIN.scene.colliders = []
+                    for entity in MAIN.scene.entities
                         for component in entity.components
                             if typeof(component) == Rigidbody
-                                push!(main.scene.rigidbodies, component)
+                                push!(MAIN.scene.rigidbodies, component)
                             elseif typeof(component) == Collider
-                                push!(main.scene.colliders, component)
+                                push!(MAIN.scene.colliders, component)
                             end
                         end
 
@@ -126,31 +124,29 @@ module SceneBuilderModule
 
                     end
 
-                    main.assets = joinpath(BasePath, "assets")
-                    main.init(isUsingEditor, dimensions, isResizable, autoScaleZoom)
+                    MAIN.assets = joinpath(BasePath, "assets")
+                    MAIN.init(isUsingEditor, dimensions, isResizable, autoScaleZoom)
 
-                    this.main = main
-                    return main
+                    return MAIN
                 end
             elseif s == :changeScene
                 function()
-                    main = this.main
                     scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), false)
-                    main.scene.entities = scene[1]
-                    main.scene.textBoxes = scene[2]
+                    MAIN.scene.entities = scene[1]
+                    MAIN.scene.textBoxes = scene[2]
 
-                    for textBox in main.scene.textBoxes
+                    for textBox in MAIN.scene.textBoxes
                         if textBox.isWorldEntity
                             textBox.centerText()
                         end
                     end
 
-                    for entity in main.scene.entities
+                    for entity in MAIN.scene.entities
                         for component in entity.components
                             if typeof(component) == Rigidbody
-                                push!(main.scene.rigidbodies, component)
+                                push!(MAIN.scene.rigidbodies, component)
                             elseif typeof(component) == Collider
-                                push!(main.scene.colliders, component)
+                                push!(MAIN.scene.colliders, component)
                             end
                         end
 
@@ -187,12 +183,7 @@ module SceneBuilderModule
                                 scriptCounter += 1
                             end
                         end
-                    end
-
-                    main.changeScene()
-
-                    this.main = main
-                        
+                    end 
                 end
             elseif s == :createNewEntity
                 function ()

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -61,8 +61,12 @@ module SceneReaderModule
             push!(res, textBoxes)
             return res
         catch e 
-            println(e)
-            Base.show_backtrace(stdout, catch_backtrace())
+            if !isEditor
+                println(e)
+                Base.show_backtrace(stdout, catch_backtrace())
+            else
+                rethrow(e)
+            end
         end
     end
 

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -36,6 +36,10 @@ module ScreenButtonModule
     function Base.getproperty(this::ScreenButton, s::Symbol)
         if s == :render
             function()
+                if this.currentTexture == C_NULL
+                    return
+                end
+
                 if !this.mouseOverSprite && this.currentTexture == this.buttonDownTexture
                     this.currentTexture = this.buttonUpTexture
                 end    
@@ -84,6 +88,18 @@ module ScreenButtonModule
         elseif s == :setParent
             function(parent)
                 this.parent = parent
+            end
+        elseif s == :destroy
+            function()
+                if !this.buttonDownTexture == C_NULL
+                    SDL2.SDL_DestroyTexture(this.buttonDownTexture)
+                end
+                if !this.buttonUpTexture == C_NULL
+                    SDL2.SDL_DestroyTexture(this.buttonUpTexture)
+                end
+                this.buttonDownTexture = C_NULL
+                this.buttonUpTexture = C_NULL
+                this.currentTexture = C_NULL
             end
         else
             try

--- a/src/UI/TextBox.jl
+++ b/src/UI/TextBox.jl
@@ -46,6 +46,10 @@ module TextBoxModule
     function Base.getproperty(this::TextBox, s::Symbol)
         if s == :render
             function(DEBUG)
+                if this.textTexture == C_NULL
+                    return
+                end
+
                 if DEBUG
                     SDL2.SDL_RenderDrawLines(JulGame.Renderer, [
                         SDL2.SDL_Point(this.position.x, this.position.y), 
@@ -109,6 +113,15 @@ module TextBoxModule
                 if this.isCenteredY
                     this.position = Math.Vector2(this.position.x, max(MAIN.scene.camera.dimensions.y/2 - this.size.y/2, 0))
                 end
+            end
+        elseif s == :destroy
+            function()
+                if this.textTexture == C_NULL
+                    return
+                end
+
+                SDL2.SDL_DestroyTexture(this.textTexture)
+                this.textTexture = C_NULL
             end
         else
             try

--- a/src/editor/Editor/Editor.jl
+++ b/src/editor/Editor/Editor.jl
@@ -489,7 +489,7 @@ module Editor
         
                     glfwMakeContextCurrent(window)
                     glfwSwapBuffers(window)
-                    gameInfo = game == C_NULL ? [] : game.gameLoop(Ref(UInt64(0)), Ref(UInt64(0)), Ref(Bool(false)), true, update)
+                    gameInfo = game == C_NULL ? [] : game.gameLoop(Ref(UInt64(0)), Ref(UInt64(0)), true, update)
                 catch e 
                     push!(latest_exceptions, e)
                     if length(latest_exceptions) > 10

--- a/src/editor/Editor/Editor.jl
+++ b/src/editor/Editor/Editor.jl
@@ -41,9 +41,8 @@ module Editor
         game = C_NULL
         try
             game = SceneLoaderModule.loadScene(sceneFileName, projectPath, true);
-        catch e 
-            println(e)
-            Base.show_backtrace(stdout, catch_backtrace())
+        catch e
+            rethrow(e)
         end
 
         return game
@@ -99,6 +98,7 @@ module Editor
             entities = []
             textBoxes = []
             screenButtons = []
+            latest_exceptions = []
             gameInfo = []
             mousePosition = C_NULL
             projectPath = ""
@@ -303,7 +303,13 @@ module Editor
 
                     @cstatic begin
                         CImGui.Begin("Debug")
-                        CImGui.Text("To be implemented")
+                        CImGui.Text("The latest 10 exceptions are:")
+                        # Todo: multiple errors and parse them to give hints. Also color code them.
+                        counter = 1
+                        for exception in latest_exceptions
+                            CImGui.Text("[$(counter)] $exception")
+                            counter += 1
+                        end
                         CImGui.End()
                     end
 
@@ -485,7 +491,11 @@ module Editor
                     glfwSwapBuffers(window)
                     gameInfo = game == C_NULL ? [] : game.gameLoop(Ref(UInt64(0)), Ref(UInt64(0)), Ref(Bool(false)), true, update)
                 catch e 
-                    println(e)
+                    push!(latest_exceptions, e)
+                    if length(latest_exceptions) > 10
+                        deleteat!(latest_exceptions, 1)
+                    end
+
                     Base.show_backtrace(stdout, catch_backtrace())
                 end
             end


### PR DESCRIPTION
This adds functionality to clean up and create a new scene while the project is running. Along with this, we can mark entities to persist between scenes.

- Created event macro that can pass arguments
- Collider events pass actual collider
- Made close a struct property of main
- Some errors passed to editor
- SDL init moved to main module
- Refactoring
