### PR TITLE
refactoring Math/Lerp.jl switching Number type to Real

### DIFF
--- a/src/Math/Lerp.jl
+++ b/src/Math/Lerp.jl
@@ -1,16 +1,26 @@
-function Lerp(a::Number, b::Number, t::Number)
-    if t < 0.0
-        t = 0.0
-    elseif t > 1.0
-        t = 1.0
-    end
+"""
+# Linear Interpolation
+--- Argument list
+- `a::Real` from
+- `b::Real` to
+- `t::Real` Earring
+"""
+function Lerp(a::Real, b::Real, t::Real)
+    # t ∈ [0,1] 
+    t = (t < 0.0) ? 0.0 : (t > 1.0) ? 1.0 : t
     
-    res = a + t * (b - a)
+    return a + t * (b - a)
 end
 
+"""
 # Smooth lerp function with quadratic easing-in-out
-function SmoothLerp(start::Number, stop::Number, t::Number)
-    t = clamp(t, 0.0, 1.0)  # Ensure t is within the range [0, 1]
+--- Argument list
+- `start::Real`
+- `stop::Real`
+- `t::Real` Earring
+"""
+function SmoothLerp(start::Real, stop::Real, t::Real)
+    t = clamp(t, 0.0, 1.0)  # Ensure t ∈ [0, 1]
     t = 0.5 - 0.5 * cos(pi * t)  # Apply quadratic easing-in-out
     return (1.0 - t) * start + t * stop
 end


### PR DESCRIPTION
Hello @Kyjor again!

I did another refactoring on Lerp and SmoothLerp Linear interpolation functions modifying the input types from **Number** to **Real** _(**Number** type does even understand Complex numbers)_ .