### PR TITLE
add concrete types to main struct

### DIFF
--- a/src/Main.jl
+++ b/src/Main.jl
@@ -10,33 +10,34 @@ module MainLoop
 	mutable struct Main
 		assets::String
 		autoScaleZoom::Bool
-		cameraBackgroundColor
+		cameraBackgroundColor::Tuple{Int64, Int64, Int64}
 		close::Bool
 		currentTestTime::Float64
-		debugTextBoxes
-		events
-		globals
-		input
+		debugTextBoxes::Vector{UI.TextBoxModule.TextBox}
+		events::Vector # what is this for ?
+		globals::Vector  # what is this for ?
+		input::Input
 		isDraggingEntity::Bool
-		lastMousePosition
-		lastMousePositionWorld
-		level
-		mousePositionWorld
-		mousePositionWorldRaw
+		lastMousePosition::Union{Math.Vector2, Math.Vector2f}
+		lastMousePositionWorld::Union{Math.Vector2, Math.Vector2f}
+        # need to work on import order so that this can be concretely typed
+		level#::JulGame.SceneManagement.SceneBuilderModule.Scene
+		mousePositionWorld::Union{Math.Vector2, Math.Vector2f}
+		mousePositionWorldRaw::Union{Math.Vector2, Math.Vector2f}
 		optimizeSpriteRendering::Bool
-		panCounter
-		panThreshold
+		panCounter::Union{Math.Vector2, Math.Vector2f}
+		panThreshold::Float64
 		scene::Scene
-		selectedEntityIndex
-		selectedEntityUpdated
-		selectedTextBoxIndex
-		screenDimensions
+		selectedEntityIndex::Int64
+		selectedEntityUpdated::Bool
+		selectedTextBoxIndex::Int64
+		screenDimensions::Union{Ptr{Nothing}, Math.Vector2}
 		shouldChangeScene::Bool
 		spriteLayers::Dict
 		targetFrameRate::Int32
 		testLength::Float64
 		testMode::Bool
-		window
+		window::Ptr{SDL2.SDL_Window}
 		windowName::String
 		zoom::Float64
 
@@ -47,10 +48,10 @@ module MainLoop
 			this.scene = Scene()
 			this.input = Input()
 
-			this.cameraBackgroundColor = [0,0,0]
+			this.cameraBackgroundColor = (0,0,0)
 			this.close = false
-			this.debugTextBoxes = []
-			this.events = []
+			this.debugTextBoxes = UI.TextBoxModule.TextBox[]
+			this.events = [] # what is this for?
 			this.input.scene = this.scene
 			this.mousePositionWorld = Math.Vector2f()
 			this.mousePositionWorldRaw = Math.Vector2f()
@@ -59,7 +60,7 @@ module MainLoop
 			this.selectedEntityIndex = -1
 			this.selectedTextBoxIndex = -1
 			this.selectedEntityUpdated = false
-			this.screenDimensions = C_NULL
+			this.screenDimensions = C_NULL # Why is this a C_NULL by default? why not Math.Vector2(0,0)?
 			this.shouldChangeScene = false
 			this.globals = []
 			this.input.main = this

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -14,8 +14,7 @@ module MainLoop
 		close::Bool
 		currentTestTime::Float64
 		debugTextBoxes::Vector{UI.TextBoxModule.TextBox}
-		events::Vector # what is this for ?
-		globals::Vector  # what is this for ?
+		globals::Vector{Any}
 		input::Input
 		isDraggingEntity::Bool
 		lastMousePosition::Union{Math.Vector2, Math.Vector2f}
@@ -31,7 +30,7 @@ module MainLoop
 		selectedEntityIndex::Int64
 		selectedEntityUpdated::Bool
 		selectedTextBoxIndex::Int64
-		screenDimensions::Union{Ptr{Nothing}, Math.Vector2}
+		screenDimensions::Math.Vector2
 		shouldChangeScene::Bool
 		spriteLayers::Dict
 		targetFrameRate::Int32
@@ -51,7 +50,6 @@ module MainLoop
 			this.cameraBackgroundColor = (0,0,0)
 			this.close = false
 			this.debugTextBoxes = UI.TextBoxModule.TextBox[]
-			this.events = [] # what is this for?
 			this.input.scene = this.scene
 			this.mousePositionWorld = Math.Vector2f()
 			this.mousePositionWorldRaw = Math.Vector2f()
@@ -60,7 +58,7 @@ module MainLoop
 			this.selectedEntityIndex = -1
 			this.selectedTextBoxIndex = -1
 			this.selectedEntityUpdated = false
-			this.screenDimensions = C_NULL # Why is this a C_NULL by default? why not Math.Vector2(0,0)?
+			this.screenDimensions = Math.Vector2(0,0)
 			this.shouldChangeScene = false
 			this.globals = []
 			this.input.main = this

--- a/src/Scene.jl
+++ b/src/Scene.jl
@@ -1,6 +1,6 @@
 ﻿mutable struct Scene
     # Need to work on import order so this can be concretely typed or at least parametricized
-    camera::Union{typeof(C_NULL), Any} #, JulGame.SceneManagement.SceneBuilderModule.Camera}
+    camera::Union{Nothing, Any} #, JulGame.SceneManagement.SceneBuilderModule.Camera}
     colliders::Vector{Any}
     entities::Vector{Any}
     rigidbodies::Vector{Any}
@@ -10,7 +10,7 @@
     function Scene()
         this = new()
 
-        this.camera = C_NULL # why use C_NULL not nothing?
+        this.camera = nothing
         this.colliders = []
         this.entities = []
         this.rigidbodies = []

--- a/src/Scene.jl
+++ b/src/Scene.jl
@@ -1,5 +1,6 @@
 ﻿mutable struct Scene
-    camera
+    # Need to work on import order so this can be concretely typed or at least parametricized
+    camera::Union{typeof(C_NULL), Any} #, JulGame.SceneManagement.SceneBuilderModule.Camera}
     colliders::Vector{Any}
     entities::Vector{Any}
     rigidbodies::Vector{Any}
@@ -9,7 +10,7 @@
     function Scene()
         this = new()
 
-        this.camera = C_NULL
+        this.camera = C_NULL # why use C_NULL not nothing?
         this.colliders = []
         this.entities = []
         this.rigidbodies = []

--- a/test/projects/ProfilingTest/Platformer/scripts/GameManager.jl
+++ b/test/projects/ProfilingTest/Platformer/scripts/GameManager.jl
@@ -27,7 +27,7 @@ function Base.getproperty(this::GameManager, s::Symbol)
     if s == :initialize
         function()
             MAIN.scene.camera.offset = JulGame.Math.Vector2f(0, -2.75)
-            MAIN.cameraBackgroundColor = [30, 111, 80]
+            MAIN.cameraBackgroundColor = (30, 111, 80)
             MAIN.optimizeSpriteRendering = true
 
             this.parent.addShape(ShapeModule.Shape(Math.Vector3(0,0,0), Math.Vector2f(10,5),  true, false, Math.Vector2f(0,0), Math.Vector2f(1.2175,0.5)))


### PR DESCRIPTION
I would love to contribute to JulGame. I thought I'd start with a small change to see if you're interested in more contributions. 

All I did here was look at the uses of every property of `Main` and add a concrete type annotation to its declaration. This should make reading and writing much faster against it.

I also changed the background color to a 3 element Tuple because it doesn't need to change lengths, and you can save allocations and memory indirections by keeping that inline.

I had trouble in two places:
1) There seems to be inconsistency in when the mouse position uses Vector2f `and when it uses `Vector2`. I just set all of the mouse properties to be a union of those. You could get a speed up by picking one and being consistent.
2) ScreenManagement is one of the fields, but it is defined after the `main` global is created so I can't give it a concrete type. This could probably be fixed pretty easily, but I was trying to keep my scope small.

Thank you for this project!!