### PR TITLE
Refactor/deanonymize-get-prop-funcs

### DIFF
--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -1,12 +1,18 @@
 using JulGame
 using .Math
+import JulGame: deprecated_get_property
 
 mutable struct Camera
     dimensions::Vector2
     offset::Vector2f
     position::Vector2f
     startingCoordinates::Vector2f
-    target#EntityModule.Entity
+
+    target::Union{
+        Ptr{Nothing}, 
+        # JulGame.EntityModule.Entity,
+        JulGame.TransformModule.Transform
+        }
     windowPos::Vector2
 
     function Camera(dimensions::Vector2, initialPosition::Vector2f, offset::Vector2f, target)
@@ -25,36 +31,34 @@ mutable struct Camera
 end
 
 function Base.getproperty(this::Camera, s::Symbol)
-    if s == :initialize
-        function()
-        end
-    elseif s == :update
-        function(newPosition = C_NULL)
-            SDL2.SDL_SetRenderDrawColor(Renderer, MAIN.cameraBackgroundColor[1], MAIN.cameraBackgroundColor[2], MAIN.cameraBackgroundColor[3], SDL2.SDL_ALPHA_OPAQUE);
-            SDL2.SDL_RenderFillRectF(Renderer, Ref(SDL2.SDL_FRect(this.windowPos.x, this.windowPos.y, this.dimensions.x, this.dimensions.y)))
+    method_props = (
+        initialize = initialize,
+        update = update,
+        setTarget = set_target
+    )
+    return deprecated_get_property(method_props, this, s)
+end
 
-            if this.target != C_NULL && newPosition == C_NULL
-                targetPos = this.target.getPosition()
-                center =  Vector2f(this.dimensions.x/SCALE_UNITS/2, this.dimensions.y/SCALE_UNITS/2)
-                targetScale = this.target.getScale()
-                this.position = targetPos - center + 0.5 * targetScale + this.offset
-                return
-            end
-            if newPosition == C_NULL
-                return
-            end
-            this.position = newPosition
-        end
-    elseif s == :setTarget
-        function(target)
-            this.target = target
-        end
-    else
-        try
-            getfield(this, s)
-        catch e
-            println(e)
-            Base.show_backtrace(stdout, catch_backtrace())
-        end
+function initialize(this::Camera)
+end
+
+function update(this::Camera, newPosition = C_NULL)
+    SDL2.SDL_SetRenderDrawColor(Renderer, MAIN.cameraBackgroundColor[1], MAIN.cameraBackgroundColor[2], MAIN.cameraBackgroundColor[3], SDL2.SDL_ALPHA_OPAQUE);
+    SDL2.SDL_RenderFillRectF(Renderer, Ref(SDL2.SDL_FRect(this.windowPos.x, this.windowPos.y, this.dimensions.x, this.dimensions.y)))
+
+    if this.target != C_NULL && newPosition == C_NULL
+        targetPos = this.target.getPosition()
+        center =  Vector2f(this.dimensions.x/SCALE_UNITS/2, this.dimensions.y/SCALE_UNITS/2)
+        targetScale = this.target.getScale()
+        this.position = targetPos - center + 0.5 * targetScale + this.offset
+        return
     end
+    if newPosition == C_NULL
+        return
+    end
+    this.position = newPosition
+end
+
+function set_target(this::Camera, target)
+    this.target = target
 end

--- a/src/Component/Animation.jl
+++ b/src/Component/Animation.jl
@@ -1,6 +1,6 @@
 module AnimationModule 
     using ..Component.JulGame
-
+    import .JulGame: deprecated_get_property
     export Animation
     mutable struct Animation
         animatedFPS::Int32
@@ -17,29 +17,27 @@ module AnimationModule
     end
 
     function Base.getproperty(this::Animation, s::Symbol)
-        if s == :updateArrayValue
-            function(value, field, index::Int32)
-                fieldToUpdate = getfield(this, field)
-                if this.getType(value) == "_Vector4"
-                    fieldToUpdate[index] = Math.Vector4(value.x, value.y, value.z, value.t)
-                end
-            end
-        elseif s == :appendArray
-            function()
-                push!(this.frames, Math.Vector4(0,0,0,0))
-            end
-        elseif s == :getType
-            function(item)
-                componentFieldType = "$(typeof(item).name.wrapper)"
-                return String(split(componentFieldType, '.')[length(split(componentFieldType, '.'))])
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
+        method_props = (
+            updateArrayValue = update_array_value,
+            appendArray = append_array,
+            getType = get_type
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+    
+    function update_array_value(this::Animation, value, field, index::Int32)
+        fieldToUpdate = getfield(this, field)
+        if this.getType(value) == "_Vector4"
+            fieldToUpdate[index] = Math.Vector4(value.x, value.y, value.z, value.t)
         end
+    end
+    
+    function append_array(this::Animation)
+        push!(this.frames, Math.Vector4(0,0,0,0))
+    end
+    
+    function get_type(this::Animation, item)
+        componentFieldType = "$(typeof(item).name.wrapper)"
+        return String(split(componentFieldType, '.')[length(split(componentFieldType, '.'))])
     end
 end

--- a/src/Component/Animator.jl
+++ b/src/Component/Animator.jl
@@ -3,7 +3,7 @@
     using ..Component.JulGame
     using ..Component.JulGame.Math
     using ..Component.SpriteModule
-
+    import ..Component.JulGame: deprecated_get_property
     export Animator
     struct Animator
         animations::Vector{Animation}
@@ -33,40 +33,43 @@
     end
 
     function Base.getproperty(this::InternalAnimator, s::Symbol)
-        if s == :getLastUpdate
-            function()
-                return this.lastUpdate
-            end
-        elseif s == :setLastUpdate
-            function(value)
-                this.lastUpdate = value
-            end
-        elseif s == :update
-            function(currentRenderTime, deltaTime)
-                Update(this, currentRenderTime, deltaTime)
-            end
-        elseif s == :setSprite
-            function(sprite)
-                this.sprite = sprite
-            end
-        elseif s == :setParent
-            function(parent)
-                this.parent = parent
-            end
-        elseif s == :appendArray
-            function()
-                push!(this.animations, Animation([Math.Vector4(0,0,0,0)], Int32(60)))
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
-        end
+        method_props = (
+            getLastUpdate = get_last_update,
+            setLastUpdate = set_last_update,
+            update = update,
+            setSprite = set_sprite,
+            setParent = set_parent,
+            appendArray = append_array
+        )
+
+        deprecated_get_property(method_props, this, s)
     end
 
+    
+    function get_last_update(this::InternalAnimator)
+        return this.lastUpdate
+    end
+
+    function set_last_update(this::InternalAnimator, value)
+        this.lastUpdate = value
+    end
+
+    function update(this::InternalAnimator, currentRenderTime, deltaTime)
+        Update(this, currentRenderTime, deltaTime)
+    end
+
+    function set_sprite(this::InternalAnimator, sprite)
+        this.sprite = sprite
+    end
+
+    function set_parent(this::InternalAnimator, parent)
+        this.parent = parent
+    end
+
+    function append_array(this::InternalAnimator)
+        push!(this.animations, Animation([Math.Vector4(0,0,0,0)], Int32(60)))
+    end
+    
     
     """
     ForceFrameUpdate(this::InternalAnimator, frameIndex::Int32)

--- a/src/Component/CircleCollider.jl
+++ b/src/Component/CircleCollider.jl
@@ -2,6 +2,7 @@
 module CircleColliderModule
     using ..Component.JulGame
     using ..Component.ColliderModule
+    import ..Component.JulGame: deprecated_get_property
 
     export CircleCollider
     struct CircleCollider
@@ -45,121 +46,122 @@ module CircleColliderModule
 
 
     function Base.getproperty(this::CircleCollider, s::Symbol)
-        if s == :getSize
-            function()
-                return this.size
-            end
-        elseif s == :checkCollisions
-            function()
-                colliders = MAIN.scene.colliders
-                #Only check the player against other colliders
-                counter = 0
-                
-                this.isGrounded = this.parent.rigidbody.grounded
-                
-
-                for i in 1:length(colliders)
-                    #TODO: Skip any out of a certain range of this. This will prevent a bunch of unnecessary collision checks
-                    if !colliders[i].getParent().isActive || !colliders[i].enabled
-                        if this.parent.rigidbody.grounded && i == length(colliders)
-                            this.parent.rigidbody.grounded = false
-                        end
-                        continue
-                    end
-                    if this != colliders[i] && this.parent.rigidbody.getVelocity().y >= 0
-                        collision = CheckCollision(this, colliders[i])
-                        if CheckIfResting(this, colliders[i])[1] == true && length(this.currentRests) > 0 && !(colliders[i] in this.currentRests)
-                            # if this collider isn't already in the list of current rests, check if it is on the same Y level and the same size as any of the current rests, if it is, then add it to current rests
-                            for j in 1:length(this.currentRests)
-                                if this.currentRests[j].getParent().transform.getPosition().y == colliders[i].getParent().transform.getPosition().y && this.currentRests[j].getSize().y == colliders[i].getSize().y
-                                    push!(this.currentRests, colliders[i])
-                                    break
-                                end
-                            end
-                        end
-                        transform = this.getParent().transform
-                        # if collision[1] == Top::CollisionDirection
-                        #     push!(this.currentCollisions, colliders[i])
-                        #     for eventToCall in this.collisionEvents
-                        #         eventToCall()
-                        #     end
-                        #     #Begin to overlap, correct position
-                        #     transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y + collision[2]))
-                        # end
-                        # if collision[1] == Left::CollisionDirection
-                        #     push!(this.currentCollisions, colliders[i])
-                        #     for eventToCall in this.collisionEvents
-                        #         eventToCall()
-                        #     end
-                        #     #Begin to overlap, correct position
-                        #     transform.setPosition(Math.Vector2f(transform.getPosition().x + collision[2], transform.getPosition().y))
-                        # end
-                        # if collision[1] == Right::CollisionDirection
-                        #     push!(this.currentCollisions, colliders[i])
-                        #     for eventToCall in this.collisionEvents
-                        #         eventToCall()
-                        #     end
-                        #     #Begin to overlap, correct position
-                        #     transform.setPosition(Math.Vector2f(transform.getPosition().x - collision[2], transform.getPosition().y))
-                        # end
-                        # if collision[1] == Bottom::CollisionDirection
-                        #this.isGrounded = collision[1]
-                        if collision[1] == true
-                            println("Collided with: ", colliders[i].getParent().name, " at ", colliders[i].getParent().transform.getPosition())
-                            push!(this.currentRests, colliders[i])
-                            for eventToCall in this.collisionEvents
-                                eventToCall()
-                            end
-                            #Begin to overlap, correct position
-                            transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y - collision[2]))
-                            this.isGrounded = true
-                        end
-                        # end
-                        # if collision[1] == Below::ColliderLocation
-                        #     push!(this.currentCollisions, colliders[i])
-                        #     for eventToCall in this.collisionEvents
-                        #         eventToCall()
-                        #     end
-                        # end
-                    end
-                end
-                for i in 1:length(this.currentRests)
-                    if CheckIfResting(this, this.currentRests[i])[1] == false
-                        deleteat!(this.currentRests, i)
-                        break
-                    end
-                end
-           
-                this.parent.rigidbody.grounded = length(this.currentRests) > 0 && this.parent.rigidbody.getVelocity().y >= 0
-                this.currentCollisions = []
-            end
-        elseif s == :setParent
-            function(parent::Any)
-                this.parent = parent
-            end
-        elseif s == :getParent
-            function()
-                return this.parent
-            end
-        elseif s == :addCollisionEvent
-            function(event)
-                push!(this.collisionEvents, event)
-            end   
-        elseif s == :getType
-            function()
-                return "CircleCollider"
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
-        end
+        method_props = (
+            getSize = get_size,
+            checkCollisions = check_collisions,
+            setParent = set_parent,
+            getParent = get_parent,
+            addCollisionEvent = add_collision_event,
+            getType = get_type
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+    
+    function get_size(this::CircleCollider)
+        return this.size
     end
 
-    function CheckCollision(colliderA::CircleCollider, colliderB::CircleCollider)
+    function check_collisions(this::CircleCollider)
+        colliders = MAIN.scene.colliders
+        #Only check the player against other colliders
+        counter = 0
+        
+        this.isGrounded = this.parent.rigidbody.grounded
+        
+
+        for i in 1:length(colliders)
+            #TODO: Skip any out of a certain range of this. This will prevent a bunch of unnecessary collision checks
+            if !colliders[i].getParent().isActive || !colliders[i].enabled
+                if this.parent.rigidbody.grounded && i == length(colliders)
+                    this.parent.rigidbody.grounded = false
+                end
+                continue
+            end
+            if this != colliders[i] && this.parent.rigidbody.getVelocity().y >= 0
+                collision = CheckCollision(this, colliders[i])
+                if CheckIfResting(this, colliders[i])[1] == true && length(this.currentRests) > 0 && !(colliders[i] in this.currentRests)
+                    # if this collider isn't already in the list of current rests, check if it is on the same Y level and the same size as any of the current rests, if it is, then add it to current rests
+                    for j in 1:length(this.currentRests)
+                        if this.currentRests[j].getParent().transform.getPosition().y == colliders[i].getParent().transform.getPosition().y && this.currentRests[j].getSize().y == colliders[i].getSize().y
+                            push!(this.currentRests, colliders[i])
+                            break
+                        end
+                    end
+                end
+                transform = this.getParent().transform
+                # if collision[1] == Top::CollisionDirection
+                #     push!(this.currentCollisions, colliders[i])
+                #     for eventToCall in this.collisionEvents
+                #         eventToCall()
+                #     end
+                #     #Begin to overlap, correct position
+                #     transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y + collision[2]))
+                # end
+                # if collision[1] == Left::CollisionDirection
+                #     push!(this.currentCollisions, colliders[i])
+                #     for eventToCall in this.collisionEvents
+                #         eventToCall()
+                #     end
+                #     #Begin to overlap, correct position
+                #     transform.setPosition(Math.Vector2f(transform.getPosition().x + collision[2], transform.getPosition().y))
+                # end
+                # if collision[1] == Right::CollisionDirection
+                #     push!(this.currentCollisions, colliders[i])
+                #     for eventToCall in this.collisionEvents
+                #         eventToCall()
+                #     end
+                #     #Begin to overlap, correct position
+                #     transform.setPosition(Math.Vector2f(transform.getPosition().x - collision[2], transform.getPosition().y))
+                # end
+                # if collision[1] == Bottom::CollisionDirection
+                #this.isGrounded = collision[1]
+                if collision[1] == true
+                    println("Collided with: ", colliders[i].getParent().name, " at ", colliders[i].getParent().transform.getPosition())
+                    push!(this.currentRests, colliders[i])
+                    for eventToCall in this.collisionEvents
+                        eventToCall()
+                    end
+                    #Begin to overlap, correct position
+                    transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y - collision[2]))
+                    this.isGrounded = true
+                end
+                # end
+                # if collision[1] == Below::ColliderLocation
+                #     push!(this.currentCollisions, colliders[i])
+                #     for eventToCall in this.collisionEvents
+                #         eventToCall()
+                #     end
+                # end
+            end
+        end
+        for i in 1:length(this.currentRests)
+            if CheckIfResting(this, this.currentRests[i])[1] == false
+                deleteat!(this.currentRests, i)
+                break
+            end
+        end
+   
+        this.parent.rigidbody.grounded = length(this.currentRests) > 0 && this.parent.rigidbody.getVelocity().y >= 0
+        this.currentCollisions = []
+    end
+
+    function set_parent(this::CircleCollider, parent::Any)
+        this.parent = parent
+    end
+
+    function get_parent(this::CircleCollider)
+        return this.parent
+    end
+
+    function add_collision_event(this::CircleCollider, event)
+        push!(this.collisionEvents, event)
+    end   
+
+    function get_type(this::CircleCollider)
+        return "CircleCollider"
+    end
+
+    function CheckCollision(a::CircleCollider, b::CircleCollider)
         # Calculate total radius squared
         totalRadiusSquared::Float64 = (a.diameter + b.diameter)^2
         # If the distance between the centers of the circles is less than the sum of their radii

--- a/src/Component/Collider.jl
+++ b/src/Component/Collider.jl
@@ -1,6 +1,7 @@
 module ColliderModule
     include("../Enums.jl")
     using ..Component.JulGame
+    import ..Component.JulGame: deprecated_get_property
 
     export Collider
     struct Collider
@@ -50,166 +51,174 @@ module ColliderModule
     end
 
     function Base.getproperty(this::InternalCollider, s::Symbol)
-        if s == :getSize
-            function()
-                return this.size
-            end
-        elseif s == :setSize
-            function(size::Math.Vector2f)
-                this.size = size
-            end
-        elseif s == :getOffset
-            function()
-                return this.offset
-            end
-        elseif s == :setOffset
-            function(offset::Math.Vector2f)
-                this.offset = offset
-            end
-        elseif s == :getTag
-            function()
-                return this.tag
-            end
-        elseif s == :setTag
-            function(tag::String)
-                this.tag = tag
-            end
-        elseif s == :getParent
-            function()
-                return this.parent
-            end
-        elseif s == :setParent
-            function(parent::Any)
-                this.parent = parent
-            end
-        elseif s == :checkCollisions
-            function()
-                colliders = MAIN.scene.colliders
-                #Only check the player against other colliders
-                counter = 0
-                onGround = this.parent.rigidbody.grounded 
-                colliderSkipCount = 0
-                colliderCheckedCount = 0
-                
-                for collider in colliders
-                    #TODO: Skip any out of a certain range of this. This will prevent a bunch of unnecessary collision checks
-                    if !collider.getParent().isActive || !collider.enabled
-                        if this.parent.rigidbody.grounded && i == length(colliders)
-                            this.parent.rigidbody.grounded = false
-                        end
-                        continue
-                    end
-                   
-                    if this != collider
-                        # check if other collider is within range of this collider, if it isn't then skip it
-                        if collider.getParent().transform.getPosition().x > this.getParent().transform.getPosition().x + this.getSize().x || collider.getParent().transform.getPosition().x + collider.getSize().x < this.getParent().transform.getPosition().x && MAIN.optimizeSpriteRendering
-                            colliderSkipCount += 1
-                            continue
-                        end
-
-                        colliderCheckedCount += 1
-                        collision = CheckCollision(this, collider)
-                        if CheckIfResting(this, collider)[1] == true && length(this.currentRests) > 0 && !(collider in this.currentRests)
-                            # if this collider isn't already in the list of current rests, check if it is on the same Y level and the same size as any of the current rests, if it is, then add it to current rests
-                            for j in 1:length(this.currentRests)
-                                if this.currentRests[j].getParent().transform.getPosition().y == collider.getParent().transform.getPosition().y && this.currentRests[j].getSize().y == collider.getSize().y
-                                    push!(this.currentRests, collider)
-                                    break
-                                end
-                            end
-                        end
-                        
-                        transform = this.getParent().transform
-                        if collision[1] == Top::CollisionDirection
-                            push!(this.currentCollisions, collider)
-                            for eventToCall in this.collisionEvents
-                                eventToCall(collider)
-                            end
-                            #Begin to overlap, correct position
-                            transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y + collision[2]))
-                        end
-                        if collision[1] == Left::CollisionDirection
-                            push!(this.currentCollisions, collider)
-                            for eventToCall in this.collisionEvents
-                                eventToCall(collider)
-                            end
-                            #Begin to overlap, correct position
-                            transform.setPosition(Math.Vector2f(transform.getPosition().x + collision[2], transform.getPosition().y))
-                        end
-                        if collision[1] == Right::CollisionDirection
-                            push!(this.currentCollisions, collider)
-                            for eventToCall in this.collisionEvents
-                                eventToCall(collider)
-                            end
-                            #Begin to overlap, correct position
-                            transform.setPosition(Math.Vector2f(transform.getPosition().x - collision[2], transform.getPosition().y))
-                        end
-                        if collision[1] == Bottom::CollisionDirection && this.parent.rigidbody.getVelocity().y >= 0
-                            push!(this.currentCollisions, collider)
-                            if !collider.isTrigger
-                                push!(this.currentRests, collider)
-                            end
-                            for eventToCall in this.collisionEvents
-                                try
-                                    eventToCall(collider)
-                                catch e
-                                    println(e)
-                                    Base.show_backtrace(stdout, catch_backtrace())
-                                end
-                            end
-                            #Begin to overlap, correct position
-                            transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y - collision[2]))
-                            if !collider.isTrigger
-                                onGround = true
-                            end
-                        end
-                        if collision[1] == Below::ColliderLocation
-                            push!(this.currentCollisions, collider)
-                            for eventToCall in this.collisionEvents
-                                eventToCall(collider)
-                            end
-                        end
-                    end
-                end
-
-                #println("Skipped $colliderSkipCount colliders, checked $colliderCheckedCount")
-
-                for i in 1:length(this.currentRests)
-                    if CheckIfResting(this, this.currentRests[i])[1] == false
-                        deleteat!(this.currentRests, i)
-                        break
-                    end
-                end
-
-                this.parent.rigidbody.grounded = length(this.currentRests) > 0 && this.parent.rigidbody.getVelocity().y >= 0
-                this.currentCollisions = InternalCollider[]
-            end
-        elseif s == :update
-            function()
-                
-            end
-        elseif s == :addCollisionEvent
-            function(event)
-                push!(this.collisionEvents, event)
-            end        
-        elseif s == :setVector2fValue
-            function(field, x, y)
-                setfield!(this, field, Math.Vector2f(x,y))
-            end
-        elseif s == :getType
-            function()
-                return "Collider"
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
-        end
+        method_props = (
+            getSize = get_size,
+            setSize = set_size,
+            getOffset = get_offset,
+            setOffset = set_offset,
+            getTag = get_tag,
+            setTag = set_tag,
+            getParent = get_parent,
+            setParent = set_parent,
+            checkCollisions = check_collisions,
+            update = update,
+            addCollisionEvent = add_collision_event,
+            setVector2fValue = set_vector2f_value,
+            getType = get_type
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+    
+    function get_size(this::InternalCollider)
+        return this.size
     end
 
+    function set_size(this::InternalCollider, size::Math.Vector2f)
+        this.size = size
+    end
+
+    function get_offset(this::InternalCollider)
+        return this.offset
+    end
+
+    function set_offset(this::InternalCollider, offset::Math.Vector2f)
+        this.offset = offset
+    end
+
+    function get_tag(this::InternalCollider)
+        return this.tag
+    end
+
+    function set_tag(this::InternalCollider, tag::String)
+        this.tag = tag
+    end
+
+    function get_parent(this::InternalCollider)
+        return this.parent
+    end
+
+    function set_parent(this::InternalCollider, parent::Any)
+        this.parent = parent
+    end
+
+    function check_collisions(this::InternalCollider)
+        colliders = MAIN.scene.colliders
+        #Only check the player against other colliders
+        counter = 0
+        onGround = this.parent.rigidbody.grounded 
+        colliderSkipCount = 0
+        colliderCheckedCount = 0
+        
+        for collider in colliders
+            #TODO: Skip any out of a certain range of this. This will prevent a bunch of unnecessary collision checks
+            if !collider.getParent().isActive || !collider.enabled
+                if this.parent.rigidbody.grounded && i == length(colliders)
+                    this.parent.rigidbody.grounded = false
+                end
+                continue
+            end
+            
+            if this != collider
+                # check if other collider is within range of this collider, if it isn't then skip it
+                if collider.getParent().transform.getPosition().x > this.getParent().transform.getPosition().x + this.getSize().x || collider.getParent().transform.getPosition().x + collider.getSize().x < this.getParent().transform.getPosition().x && MAIN.optimizeSpriteRendering
+                    colliderSkipCount += 1
+                    continue
+                end
+
+                colliderCheckedCount += 1
+                collision = CheckCollision(this, collider)
+                if CheckIfResting(this, collider)[1] == true && length(this.currentRests) > 0 && !(collider in this.currentRests)
+                    # if this collider isn't already in the list of current rests, check if it is on the same Y level and the same size as any of the current rests, if it is, then add it to current rests
+                    for j in 1:length(this.currentRests)
+                        if this.currentRests[j].getParent().transform.getPosition().y == collider.getParent().transform.getPosition().y && this.currentRests[j].getSize().y == collider.getSize().y
+                            push!(this.currentRests, collider)
+                            break
+                        end
+                    end
+                end
+                
+                transform = this.getParent().transform
+                if collision[1] == Top::CollisionDirection
+                    push!(this.currentCollisions, collider)
+                    for eventToCall in this.collisionEvents
+                        eventToCall(collider)
+                    end
+                    #Begin to overlap, correct position
+                    transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y + collision[2]))
+                end
+                if collision[1] == Left::CollisionDirection
+                    push!(this.currentCollisions, collider)
+                    for eventToCall in this.collisionEvents
+                        eventToCall(collider)
+                    end
+                    #Begin to overlap, correct position
+                    transform.setPosition(Math.Vector2f(transform.getPosition().x + collision[2], transform.getPosition().y))
+                end
+                if collision[1] == Right::CollisionDirection
+                    push!(this.currentCollisions, collider)
+                    for eventToCall in this.collisionEvents
+                        eventToCall(collider)
+                    end
+                    #Begin to overlap, correct position
+                    transform.setPosition(Math.Vector2f(transform.getPosition().x - collision[2], transform.getPosition().y))
+                end
+                if collision[1] == Bottom::CollisionDirection && this.parent.rigidbody.getVelocity().y >= 0
+                    push!(this.currentCollisions, collider)
+                    if !collider.isTrigger
+                        push!(this.currentRests, collider)
+                    end
+                    for eventToCall in this.collisionEvents
+                        try
+                            eventToCall(collider)
+                        catch e
+                            println(e)
+                            Base.show_backtrace(stdout, catch_backtrace())
+                        end
+                    end
+                    #Begin to overlap, correct position
+                    transform.setPosition(Math.Vector2f(transform.getPosition().x, transform.getPosition().y - collision[2]))
+                    if !collider.isTrigger
+                        onGround = true
+                    end
+                end
+                if collision[1] == Below::ColliderLocation
+                    push!(this.currentCollisions, collider)
+                    for eventToCall in this.collisionEvents
+                        eventToCall(collider)
+                    end
+                end
+            end
+        end
+
+        #println("Skipped $colliderSkipCount colliders, checked $colliderCheckedCount")
+
+        for i in 1:length(this.currentRests)
+            if CheckIfResting(this, this.currentRests[i])[1] == false
+                deleteat!(this.currentRests, i)
+                break
+            end
+        end
+
+        this.parent.rigidbody.grounded = length(this.currentRests) > 0 && this.parent.rigidbody.getVelocity().y >= 0
+        this.currentCollisions = InternalCollider[]
+    end
+
+    function update(this::InternalCollider)
+        
+    end
+
+    function add_collision_event(this::InternalCollider, event)
+        push!(this.collisionEvents, event)
+    end        
+
+    function set_vector2f_value(this::InternalCollider, field, x, y)
+        setfield!(this, field, Math.Vector2f(x,y))
+    end
+
+    function get_type(this::InternalCollider)
+        return "Collider"
+    end
+    
     function CheckCollision(colliderA::InternalCollider, colliderB::InternalCollider)
         # nameA = colliderA.getParent().name
         # nameB = colliderB.getParent().name

--- a/src/Component/Rigidbody.jl
+++ b/src/Component/Rigidbody.jl
@@ -1,6 +1,6 @@
 ﻿module RigidbodyModule
     using ..Component.JulGame
-
+    import ..Component.JulGame: deprecated_get_property
     export Rigidbody
     struct Rigidbody
         mass::Float64
@@ -40,56 +40,57 @@
 
     function Base.getproperty(this::InternalRigidbody, s::Symbol)
         # Todo: update this based on offset and scale
-        if s == :update
-            function(dt)
-                velocityMultiplier = Math.Vector2f(1.0, 1.0)
-                transform = this.parent.transform
-                currentPosition = transform.getPosition()
-                
-                newPosition = transform.getPosition() + this.velocity*dt + this.acceleration*(dt*dt*0.5)
-                if this.grounded
-                    newPosition = Math.Vector2f(newPosition.x, currentPosition.y)
-                    velocityMultiplier = Math.Vector2f(1.0, 0.0)
-                end
-                newAcceleration = this.applyForces()
-                newVelocity = this.velocity + (this.acceleration+newAcceleration)*(dt*0.5)
+        method_props = (
+            update = update,
+            applyForces = apply_forces,
+            getVelocity = get_velocity,
+            getParent = get_parent,
+            setVector2fValue = set_vector2f_value
+        )
+        deprecated_get_property(method_props, this, s)
+    end
 
-                transform.setPosition(newPosition)
-                SetVelocity(this, newVelocity * velocityMultiplier)
-                this.acceleration = newAcceleration
+    function update(this::InternalRigidbody, dt)
+        velocityMultiplier = Math.Vector2f(1.0, 1.0)
+        transform = this.parent.transform
+        currentPosition = transform.getPosition()
+        
+        newPosition = transform.getPosition() + this.velocity*dt + this.acceleration*(dt*dt*0.5)
+        if this.grounded
+            newPosition = Math.Vector2f(newPosition.x, currentPosition.y)
+            velocityMultiplier = Math.Vector2f(1.0, 0.0)
+        end
+        newAcceleration = this.applyForces()
+        newVelocity = this.velocity + (this.acceleration+newAcceleration)*(dt*0.5)
 
-                if this.parent.collider != C_NULL
-                    this.parent.collider.checkCollisions()
-                end
-            end
-        elseif s == :applyForces
-            function()
-                gravityAcceleration = Math.Vector2f(0.0, this.useGravity ? GRAVITY : 0.0)
-                dragForce = 0.5 * this.drag * (this.velocity * this.velocity)
-                dragAcceleration = dragForce / this.mass
-                return gravityAcceleration - dragAcceleration
-            end
-        elseif s == :getVelocity
-            function()
-                return this.velocity
-            end
-        elseif s == :getParent
-            function()
-                return this.parent
-            end
-        elseif s == :setVector2fValue
-            function(field, x, y)
-                setfield!(this, field, Math.Vector2f(x,y))
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
+        transform.setPosition(newPosition)
+        SetVelocity(this, newVelocity * velocityMultiplier)
+        this.acceleration = newAcceleration
+
+        if this.parent.collider != C_NULL
+            this.parent.collider.checkCollisions()
         end
     end
+
+    function apply_forces(this::InternalRigidbody)
+        gravityAcceleration = Math.Vector2f(0.0, this.useGravity ? GRAVITY : 0.0)
+        dragForce = 0.5 * this.drag * (this.velocity * this.velocity)
+        dragAcceleration = dragForce / this.mass
+        return gravityAcceleration - dragAcceleration
+    end
+
+    function get_velocity(this::InternalRigidbody)
+        return this.velocity
+    end
+
+    function get_parent(this::InternalRigidbody)
+        return this.parent
+    end
+
+    function set_vector2f_value(this::InternalRigidbody, field, x, y)
+        setfield!(this, field, Math.Vector2f(x,y))
+    end
+
 
     """
     AddVelocity(this::Rigidbody, velocity::Math.Vector2f)

--- a/src/Component/Shape.jl
+++ b/src/Component/Shape.jl
@@ -1,5 +1,6 @@
 module ShapeModule
     using ..Component.JulGame
+    import ..Component.JulGame: deprecated_get_property
 
     export Shape
     struct Shape
@@ -37,41 +38,38 @@ module ShapeModule
     end
 
     function Base.getproperty(this::InternalShape, s::Symbol)
-        if s == :draw
-            function()
-                if JulGame.Renderer == C_NULL
-                    return                    
-                end
+        method_props = (
+            draw = draw,
+            setParent = set_parent
+        )
+        deprecated_get_property(method_props, this, s)
+    end
 
-                parentTransform = this.parent.transform
-
-                cameraDiff = this.isWorldEntity ? 
-                Math.Vector2(MAIN.scene.camera.position.x * SCALE_UNITS, MAIN.scene.camera.position.y * SCALE_UNITS) : 
-                Math.Vector2(0,0)
-                position = this.isWorldEntity ?
-                parentTransform.getPosition() :
-                this.position
-
-                outlineRect = Ref(SDL2.SDL_FRect(convert(Int32,round((position.x + this.offset.x) * SCALE_UNITS - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2)), 
-                convert(Int32,round((position.y + this.offset.y) * SCALE_UNITS - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2)),
-                convert(Int32,round(1 * parentTransform.getScale().x * SCALE_UNITS)), 
-                convert(Int32,round(1 * parentTransform.getScale().y * SCALE_UNITS))))
-                SDL2.SDL_SetRenderDrawColor(JulGame.Renderer, this.color.x, this.color.y, this.color.z, SDL2.SDL_ALPHA_OPAQUE );      
-
-                this.isFilled ? SDL2.SDL_RenderFillRectF( JulGame.Renderer, outlineRect) : SDL2.SDL_RenderDrawRectF( JulGame.Renderer, outlineRect);
-                
-            end
-    elseif s == :setParent
-            function(parent::Any)
-                this.parent = parent
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
+    function draw(this::InternalShape)
+        if JulGame.Renderer == C_NULL
+            return                    
         end
+
+        parentTransform = this.parent.transform
+
+        cameraDiff = this.isWorldEntity ? 
+        Math.Vector2(MAIN.scene.camera.position.x * SCALE_UNITS, MAIN.scene.camera.position.y * SCALE_UNITS) : 
+        Math.Vector2(0,0)
+        position = this.isWorldEntity ?
+        parentTransform.getPosition() :
+        this.position
+
+        outlineRect = Ref(SDL2.SDL_FRect(convert(Int32,round((position.x + this.offset.x) * SCALE_UNITS - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2)), 
+        convert(Int32,round((position.y + this.offset.y) * SCALE_UNITS - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2)),
+        convert(Int32,round(1 * parentTransform.getScale().x * SCALE_UNITS)), 
+        convert(Int32,round(1 * parentTransform.getScale().y * SCALE_UNITS))))
+        SDL2.SDL_SetRenderDrawColor(JulGame.Renderer, this.color.x, this.color.y, this.color.z, SDL2.SDL_ALPHA_OPAQUE );      
+
+        this.isFilled ? SDL2.SDL_RenderFillRectF( JulGame.Renderer, outlineRect) : SDL2.SDL_RenderDrawRectF( JulGame.Renderer, outlineRect);
+        
+    end
+
+    function set_parent(this::InternalShape, parent::Any)
+        this.parent = parent
     end
 end

--- a/src/Component/Sprite.jl
+++ b/src/Component/Sprite.jl
@@ -1,5 +1,6 @@
 module SpriteModule
     using ..Component.JulGame
+    import ..Component.JulGame: deprecated_get_property
 
     export Sprite
     struct Sprite
@@ -74,143 +75,144 @@ module SpriteModule
     end
 
     function Base.getproperty(this::InternalSprite, s::Symbol)
-        if s == :draw
-            function(zoom::Float64 = 1.0)
-                if this.image == C_NULL || JulGame.Renderer == C_NULL
-                    return
-                end
-
-                if this.texture == C_NULL
-                    this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
-                    this.setColor()
-                end
-
-                parentTransform = this.parent.transform
-
-                cameraDiff = this.isWorldEntity ? 
-                Math.Vector2(MAIN.scene.camera.position.x * SCALE_UNITS - MAIN.scene.camera.windowPos.x, MAIN.scene.camera.position.y * SCALE_UNITS - MAIN.scene.camera.windowPos.y) : 
-                Math.Vector2(0,0)
-                position = this.isWorldEntity ?
-                parentTransform.getPosition() :
-                this.position
-
-                srcRect = (this.crop == Math.Vector4(0,0,0,0) || this.crop == C_NULL) ? C_NULL : Ref(SDL2.SDL_Rect(this.crop.x, this.crop.y, this.crop.z, this.crop.t))
-                dstRect = Ref(SDL2.SDL_FRect(
-                    (position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2, # TODO: Center the sprite within the entity
-                    (position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2,
-                    (this.crop == C_NULL ? this.size.x : this.crop.z) * zoom * SCALE_UNITS,
-                    (this.crop == C_NULL ? this.size.y : this.crop.t) * zoom * SCALE_UNITS
-                ))
-
-                if this.pixelsPerUnit > 0 || JulGame.PIXELS_PER_UNIT > 0
-                    ppu = this.pixelsPerUnit > 0 ? this.pixelsPerUnit : JulGame.PIXELS_PER_UNIT
-                    dstRect = Ref(SDL2.SDL_FRect(
-                        (position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - ((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS / ppu - SCALE_UNITS) / 2,
-                        (position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - ((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS / ppu - SCALE_UNITS) / 2,
-                        (srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS/ppu * zoom,
-                        (srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS/ppu * zoom
-                    ))     
-                end
-
-                srcRect = !this.isFloatPrecision ? (this.crop == Math.Vector4(0,0,0,0) || this.crop == C_NULL) ? C_NULL : Ref(SDL2.SDL_Rect(this.crop.x,this.crop.y,this.crop.z,this.crop.t)) : srcRect
-                dstRect = !this.isFloatPrecision ? Ref(SDL2.SDL_Rect(
-                    convert(Int32, round((position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2)), # TODO: Center the sprite within the entity
-                    convert(Int32, round((position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2)),
-                    convert(Int32, round(this.crop == C_NULL ? this.size.x : this.crop.z)),
-                    convert(Int32, round(this.crop == C_NULL ? this.size.y : this.crop.t))
-                )) : dstRect
-                
-                if this.pixelsPerUnit > 0 || JulGame.PIXELS_PER_UNIT > 0 && !this.isFloatPrecision
-                    ppu = this.pixelsPerUnit > 0 ? this.pixelsPerUnit : JulGame.PIXELS_PER_UNIT
-                    dstRect = Ref(SDL2.SDL_Rect(
-                        convert(Int32, round((position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - ((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS / ppu - SCALE_UNITS) / 2)),
-                        convert(Int32, round((position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - ((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS / ppu - SCALE_UNITS) / 2)),
-                        convert(Int32, round((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS/ppu)),
-                        convert(Int32, round((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS/ppu))
-                    ))     
-                end
-
-                if  this.isFloatPrecision && SDL2.SDL_RenderCopyExF(
-                    JulGame.Renderer, 
-                    this.texture, 
-                    srcRect, 
-                    dstRect,
-                    this.rotation, # ROTATION
-                    C_NULL, # Ref(SDL2.SDL_Point(0,0)) CENTER
-                    this.isFlipped ? SDL2.SDL_FLIP_HORIZONTAL : SDL2.SDL_FLIP_NONE) != 0
-
-                    error = unsafe_string(SDL2.SDL_GetError())
-                end
-
-                if  !this.isFloatPrecision && SDL2.SDL_RenderCopyEx(
-                    JulGame.Renderer, 
-                    this.texture, 
-                    srcRect, 
-                    dstRect,
-                    this.rotation, # ROTATION
-                    C_NULL, # Ref(SDL2.SDL_Point(0,0)) CENTER
-                    this.isFlipped ? SDL2.SDL_FLIP_HORIZONTAL : SDL2.SDL_FLIP_NONE) != 0
-
-                    error = unsafe_string(SDL2.SDL_GetError())
-                end
-            end
-        elseif s == :initialize
-            function()
-                if this.image == C_NULL
-                    return
-                end
-
-                this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
-            end
-        elseif s == :flip
-            function()
-                this.isFlipped = !this.isFlipped
-            end
-        elseif s == :setParent
-            function(parent::Any)
-                this.parent = parent
-            end
-        elseif s == :loadImage
-            function(imagePath::String)
-                SDL2.SDL_ClearError()
-                this.image = SDL2.IMG_Load(joinpath(BasePath, "assets", "images", imagePath))
-                error = unsafe_string(SDL2.SDL_GetError())
-                if !isempty(error)
-                    println(string("Couldn't open image! SDL Error: ", error))
-                    SDL2.SDL_ClearError()
-                    this.image = C_NULL
-                    return
-                end
-
-                surface = unsafe_wrap(Array, this.image, 10; own = false)
-                this.size = Math.Vector2(surface[1].w, surface[1].h)
-                
-                this.imagePath = imagePath
-                this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
-                this.setColor()
-            end
-        elseif s == :destroy
-            function()
-                if this.image == C_NULL
-                    return
-                end
-
-                SDL2.SDL_DestroyTexture(this.texture)
-                SDL2.SDL_FreeSurface(this.image)
-                this.image = C_NULL
-                this.texture = C_NULL
-            end
-        elseif s == :setColor
-            function ()
-                SDL2.SDL_SetTextureColorMod(this.texture, UInt8(this.color.x%256), UInt8(this.color.y%256), (this.color.z%256));
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
+        method_props = (
+            draw = draw,
+            initialize = initialize,
+            flip = flip,
+            setParent = set_parent,
+            loadImage = load_image,
+            destroy = destroy,
+            setColor = set_color
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+    function draw(this::InternalSprite, zoom::Float64 = 1.0)
+        if this.image == C_NULL || JulGame.Renderer == C_NULL
+            return
         end
+
+        if this.texture == C_NULL
+            this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
+            this.setColor()
+        end
+
+        parentTransform = this.parent.transform
+
+        cameraDiff = this.isWorldEntity ? 
+        Math.Vector2(MAIN.scene.camera.position.x * SCALE_UNITS - MAIN.scene.camera.windowPos.x, MAIN.scene.camera.position.y * SCALE_UNITS - MAIN.scene.camera.windowPos.y) : 
+        Math.Vector2(0,0)
+        position = this.isWorldEntity ?
+        parentTransform.getPosition() :
+        this.position
+
+        srcRect = (this.crop == Math.Vector4(0,0,0,0) || this.crop == C_NULL) ? C_NULL : Ref(SDL2.SDL_Rect(this.crop.x, this.crop.y, this.crop.z, this.crop.t))
+        dstRect = Ref(SDL2.SDL_FRect(
+            (position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2, # TODO: Center the sprite within the entity
+            (position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2,
+            (this.crop == C_NULL ? this.size.x : this.crop.z) * zoom * SCALE_UNITS,
+            (this.crop == C_NULL ? this.size.y : this.crop.t) * zoom * SCALE_UNITS
+        ))
+
+        if this.pixelsPerUnit > 0 || JulGame.PIXELS_PER_UNIT > 0
+            ppu = this.pixelsPerUnit > 0 ? this.pixelsPerUnit : JulGame.PIXELS_PER_UNIT
+            dstRect = Ref(SDL2.SDL_FRect(
+                (position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - ((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS / ppu - SCALE_UNITS) / 2,
+                (position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - ((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS / ppu - SCALE_UNITS) / 2,
+                (srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS/ppu * zoom,
+                (srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS/ppu * zoom
+            ))     
+        end
+
+        srcRect = !this.isFloatPrecision ? (this.crop == Math.Vector4(0,0,0,0) || this.crop == C_NULL) ? C_NULL : Ref(SDL2.SDL_Rect(this.crop.x,this.crop.y,this.crop.z,this.crop.t)) : srcRect
+        dstRect = !this.isFloatPrecision ? Ref(SDL2.SDL_Rect(
+            convert(Int32, round((position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - (parentTransform.getScale().x * SCALE_UNITS - SCALE_UNITS) / 2)), # TODO: Center the sprite within the entity
+            convert(Int32, round((position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - (parentTransform.getScale().y * SCALE_UNITS - SCALE_UNITS) / 2)),
+            convert(Int32, round(this.crop == C_NULL ? this.size.x : this.crop.z)),
+            convert(Int32, round(this.crop == C_NULL ? this.size.y : this.crop.t))
+        )) : dstRect
+        
+        if this.pixelsPerUnit > 0 || JulGame.PIXELS_PER_UNIT > 0 && !this.isFloatPrecision
+            ppu = this.pixelsPerUnit > 0 ? this.pixelsPerUnit : JulGame.PIXELS_PER_UNIT
+            dstRect = Ref(SDL2.SDL_Rect(
+                convert(Int32, round((position.x + this.offset.x) * SCALE_UNITS * zoom - cameraDiff.x - ((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS / ppu - SCALE_UNITS) / 2)),
+                convert(Int32, round((position.y + this.offset.y) * SCALE_UNITS * zoom - cameraDiff.y - ((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS / ppu - SCALE_UNITS) / 2)),
+                convert(Int32, round((srcRect == C_NULL ? this.size.x : this.crop.z) * SCALE_UNITS/ppu)),
+                convert(Int32, round((srcRect == C_NULL ? this.size.y : this.crop.t) * SCALE_UNITS/ppu))
+            ))     
+        end
+
+        if  this.isFloatPrecision && SDL2.SDL_RenderCopyExF(
+            JulGame.Renderer, 
+            this.texture, 
+            srcRect, 
+            dstRect,
+            this.rotation, # ROTATION
+            C_NULL, # Ref(SDL2.SDL_Point(0,0)) CENTER
+            this.isFlipped ? SDL2.SDL_FLIP_HORIZONTAL : SDL2.SDL_FLIP_NONE) != 0
+
+            error = unsafe_string(SDL2.SDL_GetError())
+        end
+
+        if  !this.isFloatPrecision && SDL2.SDL_RenderCopyEx(
+            JulGame.Renderer, 
+            this.texture, 
+            srcRect, 
+            dstRect,
+            this.rotation, # ROTATION
+            C_NULL, # Ref(SDL2.SDL_Point(0,0)) CENTER
+            this.isFlipped ? SDL2.SDL_FLIP_HORIZONTAL : SDL2.SDL_FLIP_NONE) != 0
+
+            error = unsafe_string(SDL2.SDL_GetError())
+        end
+    end
+
+    function initialize(this::InternalSprite)
+        if this.image == C_NULL
+            return
+        end
+
+        this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
+    end
+
+    function flip(this::InternalSprite)
+        this.isFlipped = !this.isFlipped
+    end
+
+    function set_parent(this::InternalSprite, parent::Any)
+        this.parent = parent
+    end
+
+    function load_image(this::InternalSprite, imagePath::String)
+        SDL2.SDL_ClearError()
+        this.image = SDL2.IMG_Load(joinpath(BasePath, "assets", "images", imagePath))
+        error = unsafe_string(SDL2.SDL_GetError())
+        if !isempty(error)
+            println(string("Couldn't open image! SDL Error: ", error))
+            SDL2.SDL_ClearError()
+            this.image = C_NULL
+            return
+        end
+
+        surface = unsafe_wrap(Array, this.image, 10; own = false)
+        this.size = Math.Vector2(surface[1].w, surface[1].h)
+        
+        this.imagePath = imagePath
+        this.texture = SDL2.SDL_CreateTextureFromSurface(JulGame.Renderer, this.image)
+        this.setColor()
+    end
+
+    function destroy(this::InternalSprite)
+        if this.image == C_NULL
+            return
+        end
+
+        SDL2.SDL_DestroyTexture(this.texture)
+        SDL2.SDL_FreeSurface(this.image)
+        this.image = C_NULL
+        this.texture = C_NULL
+    end
+
+    function set_color(this::InternalSprite)
+        SDL2.SDL_SetTextureColorMod(this.texture, UInt8(this.color.x%256), UInt8(this.color.y%256), (this.color.z%256));
     end
 end

--- a/src/Component/Transform.jl
+++ b/src/Component/Transform.jl
@@ -1,5 +1,6 @@
 module TransformModule
-    using ..Component.JulGame   
+    using ..Component.JulGame 
+    import ..Component.JulGame: deprecated_get_property  
     export Transform
     mutable struct Transform
         rotation::Float64
@@ -18,45 +19,49 @@ module TransformModule
     end     
 
     function Base.getproperty(this::Transform, s::Symbol)
-        if s == :getPosition
-            function()
-                return this.position
-            end
-        elseif s == :setPosition
-            function(position::Math.Vector2f)
-                this.position = position
-            end
-        elseif s == :getScale
-            function()
-                return this.scale
-            end
-        elseif s == :setScale
-            function(scale::Math.Vector2f)
-                this.scale = scale
-            end
-        elseif s == :getRotation
-            function()
-                return this.rotation
-            end
-        elseif s == :setRotation
-            function(rotation::Float64)
-                this.rotation = rotation
-            end
-        elseif s == :update
-            function()
-                #println(this.position)
-            end
-        elseif s == :setVector2fValue
-            function(field, x, y)
-                setfield!(this, field, Math.Vector2f(x,y))
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
-        end
+        method_props = (
+            getPosition = get_position,
+            setPosition = set_position,
+            getScale = get_scale,
+            setScale = set_scale,
+            getRotation = get_rotation,
+            setRotation = set_rotation,
+            update = update,
+            setVector2fValue = set_vector2f_value
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+
+
+    function get_position(this::Transform)
+        return this.position
+    end
+
+    function set_position(this::Transform, position::Math.Vector2f)
+        this.position = position
+    end
+
+    function get_scale(this::Transform)
+        return this.scale
+    end
+
+    function set_scale(this::Transform, scale::Math.Vector2f)
+        this.scale = scale
+    end
+
+    function get_rotation(this::Transform)
+        return this.rotation
+    end
+
+    function set_rotation(this::Transform, rotation::Float64)
+        this.rotation = rotation
+    end
+
+    function update(this::Transform)
+        #println(this.position)
+    end
+
+    function set_vector2f_value(this::Transform, field, x, y)
+        setfield!(this, field, Math.Vector2f(x,y))
     end
 end

--- a/src/Entity.jl
+++ b/src/Entity.jl
@@ -9,6 +9,7 @@ module EntityModule
     using ..JulGame.SoundSourceModule
     using ..JulGame.SpriteModule
     using ..JulGame.TransformModule
+    import ..JulGame: deprecated_get_property
 
     export Entity
     mutable struct Entity
@@ -51,129 +52,132 @@ module EntityModule
     end
 
     function Base.getproperty(this::Entity, s::Symbol)
-        if s == :addScript
-            function(script)
-                #println(string("Adding script of type: ", typeof(script), " to entity named " , this.name))
-                push!(this.scripts, script)
-                script.setParent(this)
-                try
-                    script.initialize()
-                catch e
-                    println(e)
-                    Base.show_backtrace(stdout, catch_backtrace())
-                end
-            end
-        elseif s == :update
-            function(deltaTime)
-                for script in this.scripts
-                    try
-                        script.update(deltaTime)
-                    catch e
-                        println(e)
-                        Base.show_backtrace(stdout, catch_backtrace())
-                    end
-                end
-            end
-        elseif s == :addAnimator
-            function(animator::Animator = Animator(Animation[Animation(Vector4[Vector4(0,0,0,0)], Int32(60))]))
-                if this.animator != C_NULL
-                    println("Animator already exists on entity named ", this.name)
-                    return
-                end
+        method_props = (
+            addScript = add_script,
+            update = update,
+            addAnimator = add_animator,
+            addCollider = add_collider,
+            addCircleCollider = add_circle_collider,
+            addRigidbody = add_rigidbody,
+            addSoundSource = add_sound_source,
+            createSoundSource = create_sound_source,
+            addSprite = add_sprite,
+            addShape = add_shape
+        )
+        deprecated_get_property(method_props, this, s)
+    end
 
-                this.animator = InternalAnimator(this::Entity, animator.animations)
-                if this.sprite != C_NULL 
-                    this.animator.setSprite(this.sprite)
-                end
 
-                return this.animator
-            end
-        elseif s == :addCollider
-            function(collider::Collider = Collider(true, false, false, Vector2f(0,0), Vector2f(1,1), "Default"))
-                if this.collider != C_NULL || this.circleCollider != C_NULL
-                    println("Collider already exists on entity named ", this.name)
-                    return
-                end
-                    
-                this.collider = InternalCollider(this::Entity, collider.size::Vector2f, collider.offset::Vector2f, collider.tag::String, collider.isTrigger::Bool, collider.isPlatformerCollider::Bool, collider.enabled::Bool)
+    function add_script(this::Entity, script)
+        #println(string("Adding script of type: ", typeof(script), " to entity named " , this.name))
+        push!(this.scripts, script)
+        script.setParent(this)
+        try
+            script.initialize()
+        catch e
+            println(e)
+            Base.show_backtrace(stdout, catch_backtrace())
+        end
+    end
 
-                return this.collider
-            end
-        elseif s == :addCircleCollider
-            function(collider::CircleCollider = CircleCollider(1.0, true, false, Vector2f(0,0), "Default"))
-                if this.collider != C_NULL || this.circleCollider != C_NULL
-                    println("Collider already exists on entity named ", this.name)
-                    return
-                end
-
-                this.circleCollider = InternalCircleCollider(this::Entity, collider.diameter, collider.offset::Vector2f, collider.tag::String, collider.isTrigger::Bool, collider.enabled::Bool)
-
-                return this.circleCollider
-            end
-        elseif s == :addRigidbody
-            function(rigidbody::Rigidbody = Rigidbody())
-                if this.rigidbody != C_NULL
-                    println("Rigidbody already exists on entity named ", this.name)
-                    return
-                end
-
-                this.rigidbody = InternalRigidbody(this::Entity; rigidbody.mass, rigidbody.useGravity)
-                
-                return this.rigidbody
-            end
-        elseif s == :addSoundSource
-            function(soundSource::SoundSource = SoundSource(Int32(-1), false, "", Int32(50)))
-                if this.soundSource != C_NULL
-                    println("SoundSource already exists on entity named ", this.name)
-                    return
-                end
-
-                this.soundSource = InternalSoundSource(this::Entity, soundSource.path, soundSource.channel, soundSource.volume, soundSource.isMusic)
-
-                return this.soundSource
-            end
-        elseif s == :createSoundSource
-            function(soundSource::SoundSource = SoundSource(Int32(-1), false, "", Int32(50)))
-                newSoundSource::InternalSoundSource = InternalSoundSource(this::Entity, soundSource.path, soundSource.channel, soundSource.volume, soundSource.isMusic)
-
-                return newSoundSource
-            end
-        elseif s == :addSprite
-            function(isCreatedInEditor::Bool = false, sprite::Sprite = Sprite(Math.Vector3(255, 255, 255), C_NULL, false, "", true, 0, Math.Vector2f(0,0), Math.Vector2f(0,0), 0, -1))
-                if this.sprite != C_NULL
-                    println("Sprite already exists on entity named ", this.name)
-                    return
-                end
-
-                this.sprite = InternalSprite(this::Entity, sprite.imagePath, sprite.crop, sprite.isFlipped, sprite.color, isCreatedInEditor; pixelsPerUnit=sprite.pixelsPerUnit, isWorldEntity=sprite.isWorldEntity, position=sprite.position, rotation=sprite.rotation, layer=sprite.layer)
-                if this.animator != C_NULL
-                    this.animator.setSprite(this.sprite)
-                end
-                this.sprite.initialize()
-
-                return this.sprite
-            end
-        elseif s == :addShape
-            function(shape::Shape = Shape(Math.Vector3(255,0,0), Math.Vector2f(1,1), true, false, Math.Vector2f(0,0), Math.Vector2f(0,0)))
-                if this.shape != C_NULL
-                    println("Shape already exists on entity named ", this.name)
-                    return
-                end
-
-                this.shape = InternalShape(this::Entity, shape.dimensions, shape.color, shape.isFilled, shape.offset; isWorldEntity = shape.isWorldEntity, position = shape.position)
-                
-                return this.shape
-            end
-        else
+    function update(this::Entity, deltaTime)
+        for script in this.scripts
             try
-                getfield(this, s)
+                script.update(deltaTime)
             catch e
                 println(e)
                 Base.show_backtrace(stdout, catch_backtrace())
-                println("")
-                println("")
-                println("")
             end
         end
     end
+
+    function add_animator(this::Entity, animator::Animator = Animator(Animation[Animation(Vector4[Vector4(0,0,0,0)], Int32(60))]))
+        if this.animator != C_NULL
+            println("Animator already exists on entity named ", this.name)
+            return
+        end
+
+        this.animator = InternalAnimator(this::Entity, animator.animations)
+        if this.sprite != C_NULL 
+            this.animator.setSprite(this.sprite)
+        end
+
+        return this.animator
+    end
+
+    function add_collider(this::Entity, collider::Collider = Collider(true, false, false, Vector2f(0,0), Vector2f(1,1), "Default"))
+        if this.collider != C_NULL || this.circleCollider != C_NULL
+            println("Collider already exists on entity named ", this.name)
+            return
+        end
+            
+        this.collider = InternalCollider(this::Entity, collider.size::Vector2f, collider.offset::Vector2f, collider.tag::String, collider.isTrigger::Bool, collider.isPlatformerCollider::Bool, collider.enabled::Bool)
+
+        return this.collider
+    end
+
+    function add_circle_collider(this::Entity, collider::CircleCollider = CircleCollider(1.0, true, false, Vector2f(0,0), "Default"))
+        if this.collider != C_NULL || this.circleCollider != C_NULL
+            println("Collider already exists on entity named ", this.name)
+            return
+        end
+
+        this.circleCollider = InternalCircleCollider(this::Entity, collider.diameter, collider.offset::Vector2f, collider.tag::String, collider.isTrigger::Bool, collider.enabled::Bool)
+
+        return this.circleCollider
+    end
+
+    function add_rigidbody(this::Entity, rigidbody::Rigidbody = Rigidbody())
+        if this.rigidbody != C_NULL
+            println("Rigidbody already exists on entity named ", this.name)
+            return
+        end
+
+        this.rigidbody = InternalRigidbody(this::Entity; rigidbody.mass, rigidbody.useGravity)
+        
+        return this.rigidbody
+    end
+
+    function add_sound_source(this::Entity, soundSource::SoundSource = SoundSource(Int32(-1), false, "", Int32(50)))
+        if this.soundSource != C_NULL
+            println("SoundSource already exists on entity named ", this.name)
+            return
+        end
+
+        this.soundSource = InternalSoundSource(this::Entity, soundSource.path, soundSource.channel, soundSource.volume, soundSource.isMusic)
+
+        return this.soundSource
+    end
+
+    function create_sound_source(this::Entity, soundSource::SoundSource = SoundSource(Int32(-1), false, "", Int32(50)))
+        newSoundSource::InternalSoundSource = InternalSoundSource(this::Entity, soundSource.path, soundSource.channel, soundSource.volume, soundSource.isMusic)
+        return newSoundSource
+    end
+
+    function add_sprite(this::Entity, isCreatedInEditor::Bool = false, sprite::Sprite = Sprite(Math.Vector3(255, 255, 255), C_NULL, false, "", true, 0, Math.Vector2f(0,0), Math.Vector2f(0,0), 0, -1))
+        if this.sprite != C_NULL
+            println("Sprite already exists on entity named ", this.name)
+            return
+        end
+
+        this.sprite = InternalSprite(this::Entity, sprite.imagePath, sprite.crop, sprite.isFlipped, sprite.color, isCreatedInEditor; pixelsPerUnit=sprite.pixelsPerUnit, isWorldEntity=sprite.isWorldEntity, position=sprite.position, rotation=sprite.rotation, layer=sprite.layer)
+        if this.animator != C_NULL
+            this.animator.setSprite(this.sprite)
+        end
+        this.sprite.initialize()
+
+        return this.sprite
+    end
+
+    function add_shape(this::Entity, shape::Shape = Shape(Math.Vector3(255,0,0), Math.Vector2f(1,1), true, false, Math.Vector2f(0,0), Math.Vector2f(0,0)))
+        if this.shape != C_NULL
+            println("Shape already exists on entity named ", this.name)
+            return
+        end
+
+        this.shape = InternalShape(this::Entity, shape.dimensions, shape.color, shape.isFilled, shape.offset; isWorldEntity = shape.isWorldEntity, position = shape.position)
+        
+        return this.shape
+    end
+
 end

--- a/src/Input/Input.jl
+++ b/src/Input/Input.jl
@@ -2,6 +2,7 @@
 module InputModule
     using ..JulGame
     using ..JulGame.Math
+    import ..JulGame: deprecated_get_property
     
     export Input
     mutable struct Input
@@ -89,276 +90,283 @@ module InputModule
     end
 
     function Base.getproperty(this::Input, s::Symbol)
-        if s == :pollInput
-            function()
-                this.buttonsPressedDown = []
-                didMouseEventOccur = false
-                event_ref = Ref{SDL2.SDL_Event}()
-                while Bool(SDL2.SDL_PollEvent(event_ref))
-                    evt = event_ref[]
-                    this.handleWindowEvents(evt)
-                    if this.editorCallback !== nothing
-                        this.editorCallback(evt)
-                    end
-                    if evt.type == SDL2.SDL_MOUSEMOTION || evt.type == SDL2.SDL_MOUSEBUTTONDOWN || evt.type == SDL2.SDL_MOUSEBUTTONUP
-                        didMouseEventOccur = true
-                        if this.scene.screenButtons != C_NULL
-                            x,y = Int32[1], Int32[1]
-                            SDL2.SDL_GetMouseState(pointer(x), pointer(y))
-                            
-                            this.mousePosition = Math.Vector2(x[1], y[1])
-                            for screenButton in this.scene.screenButtons
-                                # Check position of button to see which we are interacting with
-                                eventWasInsideThisButton = true
-                                if x[1] < screenButton.position.x + MAIN.scene.camera.startingCoordinates.x
-                                    eventWasInsideThisButton = false
-                                elseif x[1] > MAIN.scene.camera.startingCoordinates.x + screenButton.position.x + screenButton.dimensions.x * MAIN.zoom
-                                    eventWasInsideThisButton = false
-                                elseif y[1] < screenButton.position.y + MAIN.scene.camera.startingCoordinates.y
-                                    eventWasInsideThisButton = false
-                                elseif y[1] > MAIN.scene.camera.startingCoordinates.y + screenButton.position.y + screenButton.dimensions.y * MAIN.zoom
-                                    eventWasInsideThisButton = false
-                                end
+        method_props = (
+            pollInput = poll_input,
+            checkScanCode = check_scan_code,
+            handleWindowEvents = handle_window_events,
+            handleKeyEvent = handle_key_event,
+            handleMouseEvent = handle_mouse_event,
+            getButtonHeldDown = get_button_held_down,
+            getButtonPressed = get_button_pressed,
+            getButtonReleased = get_button_released,
+            getMouseButton = get_mouse_button,
+            getMouseButtonPressed = get_mouse_button_pressed,
+            getMouseButtonReleased = get_mouse_button_released
+        )
+        deprecated_get_property(method_props, this, s)
+    end
 
-                                screenButton.mouseOverSprite = eventWasInsideThisButton
-                                if !eventWasInsideThisButton
-                                    continue
-                                end
-                                
-                                screenButton.handleEvent(evt, x, y)
-                            end
-                        end
-
-                        this.handleMouseEvent(evt)
-                    end 
-
-                    #if evt.type == SDL2.SDL_JOYAXISMOTION
-                        if evt.jaxis.which == 0
-                            this.jaxis = evt.jaxis
-                        end
-                        for i in 0:this.numAxes-1
-                            axis = SDL2.SDL_JoystickGetAxis(this.joystick, i)
-                            if i < 0
-                                println("Axis $i: $(SDL2.SDL_JoystickGetAxis(this.joystick, i))")
-                            end
-                            JOYSTICK_DEAD_ZONE = 8000
-
-                            if i == 0
-                                if axis < -JOYSTICK_DEAD_ZONE
-                                    this.xDir = -1
-                                # Right of dead zone
-                                elseif axis > JOYSTICK_DEAD_ZONE
-                                    this.xDir = 1
-                                else
-                                    this.xDir = 0
-                                end
-                            elseif i == 1
-                                if axis < -JOYSTICK_DEAD_ZONE
-                                    this.yDir = -1
-                                # Right of dead zone
-                                elseif axis > JOYSTICK_DEAD_ZONE
-                                    this.yDir = 1
-                                else
-                                    this.yDir = 0
-                                end
-                            end
-
-                        end
-                        # println("x:$(this.xDir), y:$(this.yDir)")
-                        for i in 0:this.numButtons-1
-                            button = SDL2.SDL_JoystickGetButton(this.joystick, i)
-
-                            if button != 0
-                                println("Button $i: $(button)")
-                            end
-                            if i == 0 && button == 1
-                                this.button = 1
-                            elseif i == 0
-                                this.button = 0
-                            end
-                        end
-                        
-                        for i in 0:this.numHats-1
-
-                            hat = SDL2.SDL_JoystickGetHat(this.joystick, i)
-                            if hat != 0
-                                println("Hat $i: $(hat)")
-                            end
-                        end
-                        
-                    #end
-
-                    if evt.type == SDL2.SDL_QUIT
-                        this.quit = true
-                        return -1
-                    end
-                    if evt.type == SDL2.SDL_KEYDOWN && evt.key.keysym.scancode == SDL2.SDL_SCANCODE_F3
-                        this.debug = !this.debug
-                    end
-                end
-                if !didMouseEventOccur
-                    this.mouseButtonsPressedDown = []
-                    this.mouseButtonsReleased = []
-                end
-                keyboardState = unsafe_wrap(Array, SDL2.SDL_GetKeyboardState(C_NULL), 290; own = false)
-                this.handleKeyEvent(keyboardState)
+    function poll_input(this::Input)
+        this.buttonsPressedDown = []
+        didMouseEventOccur = false
+        event_ref = Ref{SDL2.SDL_Event}()
+        while Bool(SDL2.SDL_PollEvent(event_ref))
+            evt = event_ref[]
+            this.handleWindowEvents(evt)
+            if this.editorCallback !== nothing
+                this.editorCallback(evt)
             end
-        elseif s == :checkScanCode
-            function (keyboardState, keyState, scanCodes)
-                for scanCode in scanCodes
-                    if keyboardState[Int32(scanCode) + 1] == keyState
-                        return true
+            if evt.type == SDL2.SDL_MOUSEMOTION || evt.type == SDL2.SDL_MOUSEBUTTONDOWN || evt.type == SDL2.SDL_MOUSEBUTTONUP
+                didMouseEventOccur = true
+                if this.scene.screenButtons != C_NULL
+                    x,y = Int32[1], Int32[1]
+                    SDL2.SDL_GetMouseState(pointer(x), pointer(y))
+                    
+                    this.mousePosition = Math.Vector2(x[1], y[1])
+                    for screenButton in this.scene.screenButtons
+                        # Check position of button to see which we are interacting with
+                        eventWasInsideThisButton = true
+                        if x[1] < screenButton.position.x + MAIN.scene.camera.startingCoordinates.x
+                            eventWasInsideThisButton = false
+                        elseif x[1] > MAIN.scene.camera.startingCoordinates.x + screenButton.position.x + screenButton.dimensions.x * MAIN.zoom
+                            eventWasInsideThisButton = false
+                        elseif y[1] < screenButton.position.y + MAIN.scene.camera.startingCoordinates.y
+                            eventWasInsideThisButton = false
+                        elseif y[1] > MAIN.scene.camera.startingCoordinates.y + screenButton.position.y + screenButton.dimensions.y * MAIN.zoom
+                            eventWasInsideThisButton = false
+                        end
+
+                        screenButton.mouseOverSprite = eventWasInsideThisButton
+                        if !eventWasInsideThisButton
+                            continue
+                        end
+                        
+                        screenButton.handleEvent(evt, x, y)
                     end
                 end
-                return false
-            end    
-        elseif s == :handleWindowEvents
-            function (event)
-                if event.type != SDL2.SDL_WINDOWEVENT
-                    return
+
+                this.handleMouseEvent(evt)
+            end 
+
+            #if evt.type == SDL2.SDL_JOYAXISMOTION
+                if evt.jaxis.which == 0
+                    this.jaxis = evt.jaxis
                 end
-                windowEvent = event.window.event
+                for i in 0:this.numAxes-1
+                    axis = SDL2.SDL_JoystickGetAxis(this.joystick, i)
+                    if i < 0
+                        println("Axis $i: $(SDL2.SDL_JoystickGetAxis(this.joystick, i))")
+                    end
+                    JOYSTICK_DEAD_ZONE = 8000
+
+                    if i == 0
+                        if axis < -JOYSTICK_DEAD_ZONE
+                            this.xDir = -1
+                        # Right of dead zone
+                        elseif axis > JOYSTICK_DEAD_ZONE
+                            this.xDir = 1
+                        else
+                            this.xDir = 0
+                        end
+                    elseif i == 1
+                        if axis < -JOYSTICK_DEAD_ZONE
+                            this.yDir = -1
+                        # Right of dead zone
+                        elseif axis > JOYSTICK_DEAD_ZONE
+                            this.yDir = 1
+                        else
+                            this.yDir = 0
+                        end
+                    end
+
+                end
+                # println("x:$(this.xDir), y:$(this.yDir)")
+                for i in 0:this.numButtons-1
+                    button = SDL2.SDL_JoystickGetButton(this.joystick, i)
+
+                    if button != 0
+                        println("Button $i: $(button)")
+                    end
+                    if i == 0 && button == 1
+                        this.button = 1
+                    elseif i == 0
+                        this.button = 0
+                    end
+                end
                 
-                # Uncomment to debug window events
-                if windowEvent == SDL2.SDL_WINDOWEVENT_SHOWN
-                    #println(string("Window $(event.window.windowID) shown", ))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_HIDDEN
-                    #println(string("Window $(event.window.windowID) hidden"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_EXPOSED
-                    #println(string("Window $(event.window.windowID) exposed"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_MOVED
-                    #println(string("Window $(event.window.windowID) moved to $(event.window.data1),$(event.window.data2)"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_RESIZED # todo: update zoom and viewport size here
-                    #println(string("Window $(event.window.windowID) resized to $(event.window.data1)x$(event.window.data2)"))
-                    this.main.updateViewport(event.window.data1, event.window.data2)
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_SIZE_CHANGED
-                    #println(string("Window $(event.window.windowID) size changed to $(event.window.data1)x$(event.window.data2)"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_MINIMIZED
-                    #println(string("Window $(event.window.windowID) minimized"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_MAXIMIZED
-                    #println(string("Window $(event.window.windowID) maximized"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_RESTORED
-                    #println(string("Window $(event.window.windowID) restored"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_ENTER
-                    #println(string("Mouse entered window $(event.window.windowID)"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_LEAVE
-                    #println(string("Mouse left window $(event.window.windowID)"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_FOCUS_GAINED
-                    #println(string("Window $(event.window.windowID) gained keyboard focus"))
-                    this.isWindowFocused = true
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_FOCUS_LOST
-                    #println(string("Window $(event.window.windowID) lost keyboard focus"))
-                    this.isWindowFocused = false
+                for i in 0:this.numHats-1
 
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_CLOSE
-                    #println(string("Window $(event.window.windowID) closed"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_TAKE_FOCUS
-                    #println(string("Window $(event.window.windowID) is offered a focus"))
-                elseif windowEvent == SDL2.SDL_WINDOWEVENT_HIT_TEST
-                    #println(string("Window $(event.window.windowID) has a special hit test"))
-                else
-                    #println(string("Window $(event.window.windowID) got unknown event $(event.window.event)"))   
-                end    
-            end
-        elseif s == :handleKeyEvent
-            function(keyboardState)
-                buttonsPressedDown = this.buttonsPressedDown
-
-                count = 1
-                for scanCode in this.scanCodes
-                    button = scanCode[2]
-                    if this.checkScanCode(keyboardState, 1, [scanCode[1]]) && !(button in this.buttonsHeldDown)
-                        push!(buttonsPressedDown, button)
-                        push!(this.buttonsHeldDown, button)
-                    elseif this.checkScanCode(keyboardState, 0, [scanCode[1]])
-                        if button in this.buttonsHeldDown
-                            deleteat!(this.buttonsHeldDown, findfirst(x -> x == button, this.buttonsHeldDown))
-                        end
+                    hat = SDL2.SDL_JoystickGetHat(this.joystick, i)
+                    if hat != 0
+                        println("Hat $i: $(hat)")
                     end
                 end
-                this.buttonsPressedDown = buttonsPressedDown
-            end
-        elseif s == :handleMouseEvent
-            function(event)
-                mouseButtons = []
-                mouseButtonsUp = []
-                mouseButton = C_NULL
-                mouseButtonUp = C_NULL
+                
+            #end
 
-                if event.button.button == SDL2.SDL_BUTTON_LEFT || event.button.button == SDL2.SDL_BUTTON_MIDDLE || event.button.button == SDL2.SDL_BUTTON_RIGHT
-                    if !(mouseButton in mouseButtons)
-                        if event.type == SDL2.SDL_MOUSEBUTTONDOWN
-                            mouseButton = event.button.button
-                            push!(mouseButtons, mouseButton)
-                        elseif event.type == SDL2.SDL_MOUSEBUTTONUP
-                            mouseButtonUp = event.button.button
-                            push!(mouseButtonsUp, mouseButtonUp)
-                        end
-                    end
-                end
-
-                this.mouseButtonsPressedDown = mouseButtons
-                for mouseButton in mouseButtons
-                    if !(mouseButton in this.mouseButtonsHeldDown)
-                        push!(this.mouseButtonsHeldDown, mouseButton)
-                    end
-                end
-                for mouseButton in mouseButtonsUp
-                    if mouseButton in this.mouseButtonsHeldDown
-                        deleteat!(this.mouseButtonsHeldDown, findfirst(x -> x == mouseButton, this.mouseButtonsHeldDown))
-                    end
-                end
-                this.mouseButtonsReleased = mouseButtonsUp
+            if evt.type == SDL2.SDL_QUIT
+                this.quit = true
+                return -1
             end
-        elseif s == :getButtonHeldDown
-            function(button)
-                if button in this.buttonsHeldDown
-                    return true
-                end
-                return false
-            end
-        elseif s == :getButtonPressed
-            function(button)
-                if button in this.buttonsPressedDown
-                    return true
-                end
-                return false
-            end
-        elseif s == :getButtonReleased
-            function(button)
-                if button in this.buttonsReleased
-                    return true
-                end
-                return false
-            end
-        elseif s == :getMouseButton
-            function(button)
-                if button in this.mouseButtonsHeldDown
-                    return true
-                end
-                return false
-            end
-        elseif s == :getMouseButtonPressed
-            function(button)
-                if button in this.mouseButtonsPressedDown
-                    return true
-                end
-                return false
-            end
-        elseif s == :getMouseButtonReleased
-            function(button)
-                if button in this.mouseButtonsReleased
-                    return true
-                end
-                return false
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
+            if evt.type == SDL2.SDL_KEYDOWN && evt.key.keysym.scancode == SDL2.SDL_SCANCODE_F3
+                this.debug = !this.debug
             end
         end
+        if !didMouseEventOccur
+            this.mouseButtonsPressedDown = []
+            this.mouseButtonsReleased = []
+        end
+        keyboardState = unsafe_wrap(Array, SDL2.SDL_GetKeyboardState(C_NULL), 290; own = false)
+        this.handleKeyEvent(keyboardState)
     end
+
+    function check_scan_code(this::Input, keyboardState, keyState, scanCodes)
+        for scanCode in scanCodes
+            if keyboardState[Int32(scanCode) + 1] == keyState
+                return true
+            end
+        end
+        return false
+    end    
+
+    function handle_window_events(this::Input, event)
+        if event.type != SDL2.SDL_WINDOWEVENT
+            return
+        end
+        windowEvent = event.window.event
+        
+        # Uncomment to debug window events
+        if windowEvent == SDL2.SDL_WINDOWEVENT_SHOWN
+            #println(string("Window $(event.window.windowID) shown"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_HIDDEN
+            #println(string("Window $(event.window.windowID) hidden"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_EXPOSED
+            #println(string("Window $(event.window.windowID) exposed"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_MOVED
+            #println(string("Window $(event.window.windowID) moved to $(event.window.data1),$(event.window.data2)"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_RESIZED # todo: update zoom and viewport size here
+            #println(string("Window $(event.window.windowID) resized to $(event.window.data1)x$(event.window.data2)"))
+            this.main.updateViewport(event.window.data1, event.window.data2)
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_SIZE_CHANGED
+            #println(string("Window $(event.window.windowID) size changed to $(event.window.data1)x$(event.window.data2)"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_MINIMIZED
+            #println(string("Window $(event.window.windowID) minimized"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_MAXIMIZED
+            #println(string("Window $(event.window.windowID) maximized"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_RESTORED
+            #println(string("Window $(event.window.windowID) restored"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_ENTER
+            #println(string("Mouse entered window $(event.window.windowID)"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_LEAVE
+            #println(string("Mouse left window $(event.window.windowID)"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_FOCUS_GAINED
+            #println(string("Window $(event.window.windowID) gained keyboard focus"))
+            this.isWindowFocused = true
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_FOCUS_LOST
+            #println(string("Window $(event.window.windowID) lost keyboard focus"))
+            this.isWindowFocused = false
+
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_CLOSE
+            #println(string("Window $(event.window.windowID) closed"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_TAKE_FOCUS
+            #println(string("Window $(event.window.windowID) is offered a focus"))
+        elseif windowEvent == SDL2.SDL_WINDOWEVENT_HIT_TEST
+            #println(string("Window $(event.window.windowID) has a special hit test"))
+        else
+            #println(string("Window $(event.window.windowID) got unknown event $(event.window.event)"))   
+        end    
+    end
+
+    function handle_key_event(this::Input, keyboardState)
+        buttonsPressedDown = this.buttonsPressedDown
+
+        count = 1
+        for scanCode in this.scanCodes
+            button = scanCode[2]
+            if this.checkScanCode(keyboardState, 1, [scanCode[1]]) && !(button in this.buttonsHeldDown)
+                push!(buttonsPressedDown, button)
+                push!(this.buttonsHeldDown, button)
+            elseif this.checkScanCode(keyboardState, 0, [scanCode[1]])
+                if button in this.buttonsHeldDown
+                    deleteat!(this.buttonsHeldDown, findfirst(x -> x == button, this.buttonsHeldDown))
+                end
+            end
+        end
+        this.buttonsPressedDown = buttonsPressedDown
+    end
+
+    function handle_mouse_event(this::Input, event)
+        mouseButtons = []
+        mouseButtonsUp = []
+        mouseButton = C_NULL
+        mouseButtonUp = C_NULL
+
+        if event.button.button == SDL2.SDL_BUTTON_LEFT || event.button.button == SDL2.SDL_BUTTON_MIDDLE || event.button.button == SDL2.SDL_BUTTON_RIGHT
+            if !(mouseButton in mouseButtons)
+                if event.type == SDL2.SDL_MOUSEBUTTONDOWN
+                    mouseButton = event.button.button
+                    push!(mouseButtons, mouseButton)
+                elseif event.type == SDL2.SDL_MOUSEBUTTONUP
+                    mouseButtonUp = event.button.button
+                    push!(mouseButtonsUp, mouseButtonUp)
+                end
+            end
+        end
+
+        this.mouseButtonsPressedDown = mouseButtons
+        for mouseButton in mouseButtons
+            if !(mouseButton in this.mouseButtonsHeldDown)
+                push!(this.mouseButtonsHeldDown, mouseButton)
+            end
+        end
+        for mouseButton in mouseButtonsUp
+            if mouseButton in this.mouseButtonsHeldDown
+                deleteat!(this.mouseButtonsHeldDown, findfirst(x -> x == mouseButton, this.mouseButtonsHeldDown))
+            end
+        end
+        this.mouseButtonsReleased = mouseButtonsUp
+    end
+
+    function get_button_held_down(this::Input, button)
+        if button in this.buttonsHeldDown
+            return true
+        end
+        return false
+    end
+
+    function get_button_pressed(this::Input, button)
+        if button in this.buttonsPressedDown
+            return true
+        end
+        return false
+    end
+
+    function get_button_released(this::Input, button)
+        if button in this.buttonsReleased
+            return true
+        end
+        return false
+    end
+
+    function get_mouse_button(this::Input, button)
+        if button in this.mouseButtonsHeldDown
+            return true
+        end
+        return false
+    end
+
+    function get_mouse_button_pressed(this::Input, button)
+        if button in this.mouseButtonsPressedDown
+            return true
+        end
+        return false
+    end
+
+    function get_mouse_button_released(this::Input, button)
+        if button in this.mouseButtonsReleased
+            return true
+        end
+        return false
+    end
+    
 end

--- a/src/Scene.jl
+++ b/src/Scene.jl
@@ -21,31 +21,29 @@
 end
 
 function Base.getproperty(this::Scene, s::Symbol)
-    if s == :update
-        function()
-            # update here
-        end
-    elseif s == :getCollidersInRange
-        function(originCollider)
-            # search for colliders in colliders that could possibly touch origin collider and return as array
-        end
-    elseif s == :getEntityByName
-        function(name)
-            for entity in this.entities
-                if entity.name == name
-                    return entity
-                end
-            end
+    method_props = (
+        update = update,
+        getCollidersInRange = get_colliders_in_range,
+        getEntityByName = get_entity_by_name
+    )
+    deprecated_get_property(method_props, this, s)
+end
 
-            @warn "No entity with name $name found"
-            return C_NULL
-        end
-    else
-        try
-            getfield(this, s)
-        catch e
-            println(e)
-            Base.show_backtrace(stdout, catch_backtrace())
+function update(this::Scene)
+    # update here
+end
+
+function get_colliders_in_range(this::Scene, originCollider)
+    # search for colliders in colliders that could possibly touch origin collider and return as array
+end
+
+function get_entity_by_name(this::Scene, name)
+    for entity in this.entities
+        if entity.name == name
+            return entity
         end
     end
+
+    @warn "No entity with name $name found"
+    return C_NULL
 end

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -1,6 +1,7 @@
 module ScreenButtonModule    
     using ..UI.JulGame
     using ..UI.JulGame.Math
+    import ..UI.JulGame: deprecated_get_property
 
     export ScreenButton
     mutable struct ScreenButton
@@ -44,84 +45,85 @@ module ScreenButtonModule
     end
 
     function Base.getproperty(this::ScreenButton, s::Symbol)
-        if s == :render
-            function()
-                if !this.isInitialized
-                    this.initialize()
-                end
+        method_props = (
+            render = render,
+            initialize = initialize,
+            addClickEvent = add_click_event,
+            handleEvent = handle_event,
+            destroy = destroy
+        )
+        deprecated_get_property(method_props, this, s)
+    end
+    
 
-                if this.currentTexture == C_NULL || this.textTexture == C_NULL
-                    return
-                end
-
-                if !this.mouseOverSprite && this.currentTexture == this.buttonDownTexture
-                    this.currentTexture = this.buttonUpTexture
-                end    
-                @assert SDL2.SDL_RenderCopyExF(
-                    JulGame.Renderer, 
-                    this.currentTexture, 
-                    C_NULL, 
-                    Ref(SDL2.SDL_FRect(this.position.x, this.position.y, this.dimensions.x,this.dimensions.y)), 
-                    0.0, 
-                    C_NULL, 
-                    SDL2.SDL_FLIP_NONE) == 0 "error rendering image: $(unsafe_string(SDL2.SDL_GetError()))"
-
-                @assert SDL2.SDL_RenderCopyF(JulGame.Renderer, this.textTexture, C_NULL, Ref(SDL2.SDL_FRect(this.position.x + this.textOffset.x, this.position.y + this.textOffset.y,this.textSize.x,this.textSize.y))) == 0 "error rendering button text: $(unsafe_string(SDL2.SDL_GetError()))"
-            end
-        elseif s == :initialize
-            function()
-                this.buttonDownTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, this.buttonDownSprite)
-                this.buttonUpTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, this.buttonUpSprite)
-                this.currentTexture = this.buttonUpTexture
-
-                if this.fontPath == C_NULL
-                    this.isInitialized = true
-                    return
-                end
-
-                font = CallSDLFunction(SDL2.TTF_OpenFont, joinpath(JulGame.BasePath, "assets", "fonts", this.fontPath), 64)
-                text = font != C_NULL ? CallSDLFunction(SDL2.TTF_RenderUTF8_Blended, font, this.text, SDL2.SDL_Color(255,255,255,255)) : C_NULL
-                surface = unsafe_wrap(Array, text, 10; own = false)
-                this.textSize = Math.Vector2(surface[1].w, surface[1].h)
-                this.textTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, text)
-                this.isInitialized = true
-            end
-        elseif s == :addClickEvent
-            function(event)
-                push!(this.clickEvents, event)
-            end
-        elseif s == :handleEvent
-            function(evt, x, y)
-                if evt.type == evt.type == SDL2.SDL_MOUSEBUTTONDOWN
-                    this.currentTexture = this.buttonDownTexture
-                elseif evt.type == SDL2.SDL_MOUSEBUTTONUP
-                    this.currentTexture = this.buttonUpTexture
-                    for eventToCall in this.clickEvents
-                        eventToCall()
-                    end
-                elseif evt.type == SDL2.SDL_MOUSEMOTION
-                    #println("mouse move")
-                end 
-            end
-        elseif s == :destroy
-            function()
-                if this.buttonDownTexture != C_NULL
-                    SDL2.SDL_DestroyTexture(this.buttonDownTexture)
-                end
-                if this.buttonUpTexture != C_NULL
-                    SDL2.SDL_DestroyTexture(this.buttonUpTexture)
-                end
-                this.buttonDownTexture = C_NULL
-                this.buttonUpTexture = C_NULL
-                this.currentTexture = C_NULL
-            end
-        else
-            try
-                getfield(this, s)
-            catch e
-                println(e)
-                Base.show_backtrace(stdout, catch_backtrace())
-            end
+    function render(this::ScreenButton)
+        if !this.isInitialized
+            this.initialize()
         end
+
+        if this.currentTexture == C_NULL || this.textTexture == C_NULL
+            return
+        end
+
+        if !this.mouseOverSprite && this.currentTexture == this.buttonDownTexture
+            this.currentTexture = this.buttonUpTexture
+        end    
+        @assert SDL2.SDL_RenderCopyExF(
+            JulGame.Renderer, 
+            this.currentTexture, 
+            C_NULL, 
+            Ref(SDL2.SDL_FRect(this.position.x, this.position.y, this.dimensions.x,this.dimensions.y)), 
+            0.0, 
+            C_NULL, 
+            SDL2.SDL_FLIP_NONE) == 0 "error rendering image: $(unsafe_string(SDL2.SDL_GetError()))"
+
+        @assert SDL2.SDL_RenderCopyF(JulGame.Renderer, this.textTexture, C_NULL, Ref(SDL2.SDL_FRect(this.position.x + this.textOffset.x, this.position.y + this.textOffset.y,this.textSize.x,this.textSize.y))) == 0 "error rendering button text: $(unsafe_string(SDL2.SDL_GetError()))"
+    end
+
+    function initialize(this::ScreenButton)
+        this.buttonDownTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, this.buttonDownSprite)
+        this.buttonUpTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, this.buttonUpSprite)
+        this.currentTexture = this.buttonUpTexture
+
+        if this.fontPath == C_NULL
+            this.isInitialized = true
+            return
+        end
+
+        font = CallSDLFunction(SDL2.TTF_OpenFont, joinpath(JulGame.BasePath, "assets", "fonts", this.fontPath), 64)
+        text = font != C_NULL ? CallSDLFunction(SDL2.TTF_RenderUTF8_Blended, font, this.text, SDL2.SDL_Color(255,255,255,255)) : C_NULL
+        surface = unsafe_wrap(Array, text, 10; own = false)
+        this.textSize = Math.Vector2(surface[1].w, surface[1].h)
+        this.textTexture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, text)
+        this.isInitialized = true
+    end
+
+    function add_click_event(this::ScreenButton, event)
+        push!(this.clickEvents, event)
+    end
+
+    function handle_event(this::ScreenButton, evt, x, y)
+        if evt.type == evt.type == SDL2.SDL_MOUSEBUTTONDOWN
+            this.currentTexture = this.buttonDownTexture
+        elseif evt.type == SDL2.SDL_MOUSEBUTTONUP
+            this.currentTexture = this.buttonUpTexture
+            for eventToCall in this.clickEvents
+                eventToCall()
+            end
+        elseif evt.type == SDL2.SDL_MOUSEMOTION
+            #println("mouse move")
+        end 
+    end
+
+    function destroy(this::ScreenButton)
+        if this.buttonDownTexture != C_NULL
+            SDL2.SDL_DestroyTexture(this.buttonDownTexture)
+        end
+        if this.buttonUpTexture != C_NULL
+            SDL2.SDL_DestroyTexture(this.buttonUpTexture)
+        end
+        this.buttonDownTexture = C_NULL
+        this.buttonUpTexture = C_NULL
+        this.currentTexture = C_NULL
     end
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -12,6 +12,15 @@ function CallSDLFunction(func::Function, args...)
     return ret
 end
 
+"""
+    deprecated_get_property(method_lookup, this::T, s::Symbol) where T
+
+This function is used to deprecate the old way of accessing functions in structs.
+The method_lookup should be a tuple of the form `(old_property_name = new_function_name, ...)`.
+
+Once the old property uses are excised from the code base, the `@warn` line can be turned back on 
+to warn the user of a bad property access.
+"""
 function deprecated_get_property(method_lookup, this::T, s::Symbol) where T
     if haskey(method_lookup, s)
         f = method_lookup[s]

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -11,3 +11,12 @@ function CallSDLFunction(func::Function, args...)
 
     return ret
 end
+
+function deprecated_get_property(method_lookup, this::T, s::Symbol) where T
+    if haskey(method_lookup, s)
+        f = method_lookup[s]
+        # @warn "Using get_property to access the function $s from $T is deprecated. Please call $(typeof(f)) instead"
+        return (args...; kwargs...) -> method_lookup[s](this, args...; kwargs...)
+    end
+    return getfield(this, s)
+end


### PR DESCRIPTION
I don't want to break the api, so I created a simple get_property function that looks up the correct function and then returns an anonymous function with "this" inserted in the first position. 

I commented out a warning log about deprecation because basically every function call in the code base hits that warning at the moment. But once everything is moved to using direct function calls, we can turn on the warning to track down the last of them.

To be clear: I didn't change any logic here. Just renamed functions to snake_case and moved them out of `get_property`