### PR TITLE
Create screen buttons in the editor

### DIFF
--- a/docs/.astro/types.d.ts
+++ b/docs/.astro/types.d.ts
@@ -284,9 +284,9 @@ declare module 'astro:content' {
   collection: "docs";
   data: InferEntrySchema<"docs">
 } & { render(): Render[".md"] };
-"reference/Shape/properties/dimensions.md": {
-	id: "reference/Shape/properties/dimensions.md";
-  slug: "reference/shape/properties/dimensions";
+"reference/Shape/properties/size.md": {
+	id: "reference/Shape/properties/size.md";
+  slug: "reference/shape/properties/size";
   body: string;
   collection: "docs";
   data: InferEntrySchema<"docs">

--- a/docs/src/content/docs/reference/Shape/properties/dimensions.md
+++ b/docs/src/content/docs/reference/Shape/properties/dimensions.md
@@ -1,8 +1,8 @@
 ---
-title: Shape.dimensions
-description: An xy value for the dimensions of the shape (only square right now).
+title: Shape.size
+description: An xy value for the size of the shape (only square right now).
 ---
 
-An xy value for the dimensions of the shape (only square right now).
+An xy value for the size of the shape (only square right now).
 
 Example:

--- a/docs/src/content/docs/reference/Shape/shape.md
+++ b/docs/src/content/docs/reference/Shape/shape.md
@@ -10,7 +10,7 @@ sidebar:
 | Property | Description                    |
 |-------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | [color](/JulGame.jl/reference/shape/properties/color/)           | An rgb value for the color of the given shape. |
-| [dimensions](/JulGame.jl/reference/shape/properties/dimensions/)           | An xy value for the dimensions of the shape (only square right now). |
+| [size](/JulGame.jl/reference/shape/properties/size/)           | An xy value for the size of the shape (only square right now). |
 | [isFilled](/JulGame.jl/reference/shape/properties/isFilled/)           | A flag that determines whether or not the shape is filled or not. |
 | [offset](/JulGame.jl/reference/shape/properties/offset/)           | An xy value for the difference in position between the shape and its parent transform. |
 | [parent](/JulGame.jl/reference/shape/properties/parent/)           | The parent entity of the shape. |

--- a/src/Camera.jl
+++ b/src/Camera.jl
@@ -4,7 +4,7 @@ import JulGame: deprecated_get_property
 import JulGame.Component
 
 mutable struct Camera
-    dimensions::Vector2
+    size::Vector2
     offset::Vector2f
     position::Vector2f
     startingCoordinates::Vector2f
@@ -16,10 +16,10 @@ mutable struct Camera
         }
     windowPos::Vector2
 
-    function Camera(dimensions::Vector2, initialPosition::Vector2f, offset::Vector2f, target)
+    function Camera(size::Vector2, initialPosition::Vector2f, offset::Vector2f, target)
         this = new()
         
-        this.dimensions = dimensions
+        this.size = size
         this.position = initialPosition
         this.offset = Vector2f(offset.x, offset.y)
         this.target = target
@@ -45,11 +45,11 @@ end
 
 function update(this::Camera, newPosition = C_NULL)
     SDL2.SDL_SetRenderDrawColor(Renderer, MAIN.cameraBackgroundColor[1], MAIN.cameraBackgroundColor[2], MAIN.cameraBackgroundColor[3], SDL2.SDL_ALPHA_OPAQUE);
-    SDL2.SDL_RenderFillRectF(Renderer, Ref(SDL2.SDL_FRect(this.windowPos.x, this.windowPos.y, this.dimensions.x, this.dimensions.y)))
+    SDL2.SDL_RenderFillRectF(Renderer, Ref(SDL2.SDL_FRect(this.windowPos.x, this.windowPos.y, this.size.x, this.size.y)))
 
     if this.target != C_NULL && newPosition == C_NULL
         targetPos = this.target.position
-        center =  Vector2f(this.dimensions.x/SCALE_UNITS/2, this.dimensions.y/SCALE_UNITS/2)
+        center =  Vector2f(this.size.x/SCALE_UNITS/2, this.size.y/SCALE_UNITS/2)
         targetScale = this.target.scale
         this.position = targetPos - center + 0.5 * targetScale + this.offset
         return

--- a/src/CommonFunctions.jl
+++ b/src/CommonFunctions.jl
@@ -28,6 +28,7 @@ function get_type end
 function get_velocity end
 function handle_event end
 function initialize end
+function load_button_sprite_editor end
 function load_font end
 function load_image end
 function load_sound end

--- a/src/Component/Shape.jl
+++ b/src/Component/Shape.jl
@@ -5,7 +5,7 @@ module ShapeModule
     export Shape
     struct Shape
         color::Math.Vector3
-        dimensions::Math.Vector2f
+        size::Math.Vector2f
         isFilled::Bool
         isWorldEntity::Bool
         offset::Math.Vector2f
@@ -15,19 +15,19 @@ module ShapeModule
     export InternalShape
     mutable struct InternalShape
         color::Math.Vector3
-        dimensions::Math.Vector2f
         isFilled::Bool
         isWorldEntity::Bool
         layer::Int32
         offset::Math.Vector2f
         position::Math.Vector2f
         parent::Any # Entity
+        size::Math.Vector2f
         
-        function InternalShape(parent::Any, dimensions::Math.Vector2f = Math.Vector2f(1,1), color::Math.Vector3 = Math.Vector3(255,0,0), isFilled::Bool = true, offset::Math.Vector2f = Math.Vector2f(0,0); isWorldEntity::Bool = true, position::Math.Vector2f = Math.Vector2f(0,0))
+        function InternalShape(parent::Any, size::Math.Vector2f = Math.Vector2f(1,1), color::Math.Vector3 = Math.Vector3(255,0,0), isFilled::Bool = true, offset::Math.Vector2f = Math.Vector2f(0,0); isWorldEntity::Bool = true, position::Math.Vector2f = Math.Vector2f(0,0))
             this = new()
             
             this.color = color
-            this.dimensions = dimensions
+            this.size = size
             this.isFilled = isFilled
             this.isWorldEntity = isWorldEntity
             this.layer = 0

--- a/src/Entity.jl
+++ b/src/Entity.jl
@@ -179,7 +179,7 @@ module EntityModule
             return
         end
 
-        this.shape = InternalShape(this::Entity, shape.dimensions, shape.color, shape.isFilled, shape.offset; isWorldEntity = shape.isWorldEntity, position = shape.position)
+        this.shape = InternalShape(this::Entity, shape.size, shape.color, shape.isFilled, shape.offset; isWorldEntity = shape.isWorldEntity, position = shape.position)
         
         return this.shape
     end

--- a/src/Input/Input.jl
+++ b/src/Input/Input.jl
@@ -128,11 +128,11 @@ module InputModule
                         eventWasInsideThisButton = true
                         if x[1] < screenButton.position.x + MAIN.scene.camera.startingCoordinates.x
                             eventWasInsideThisButton = false
-                        elseif x[1] > MAIN.scene.camera.startingCoordinates.x + screenButton.position.x + screenButton.dimensions.x * MAIN.zoom
+                        elseif x[1] > MAIN.scene.camera.startingCoordinates.x + screenButton.position.x + screenButton.size.x * MAIN.zoom
                             eventWasInsideThisButton = false
                         elseif y[1] < screenButton.position.y + MAIN.scene.camera.startingCoordinates.y
                             eventWasInsideThisButton = false
-                        elseif y[1] > MAIN.scene.camera.startingCoordinates.y + screenButton.position.y + screenButton.dimensions.y * MAIN.zoom
+                        elseif y[1] > MAIN.scene.camera.startingCoordinates.y + screenButton.position.y + screenButton.size.y * MAIN.zoom
                             eventWasInsideThisButton = false
                         end
 

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -800,7 +800,11 @@ function GameLoop(this::Main, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysi
 				try
 					if selectedEntity != nothing
 						if this.input.getButtonPressed("DELETE")
-							println("delete entity with name $(selectedEntity.name) and id $(selectedEntity.id)")
+							# println("delete entity with name $(selectedEntity.name) and id $(selectedEntity.id)")
+							index = findfirst(x -> x == selectedEntity, this.scene.entities)
+							if index !== nothing
+								MainLoop.DestroyEntity(this.scene.entities[index])
+							end
 						end
 
 						pos = selectedEntity.transform.position

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -208,6 +208,9 @@ module MainLoop
 			end
         elseif this.input.getMouseButton(SDL2.SDL_BUTTON_LEFT) && (this.selectedEntity !== nothing || this.selectedUIElementIndex != -1) && this.isWindowFocused  # TODO: figure out what this meant && this.selectedEntityIndex != this.selectedUIElementIndex
             # TODO: Make this work for textboxes
+			if "$(typeof(this.selectedEntity))" != "JulGame.EntityModule.Entity"
+				return
+			end
             snapping = false
             if this.input.getButtonHeldDown("LCTRL")
                 snapping = true

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -392,9 +392,6 @@ function InitializeScriptsAndComponents(this::Main, isUsingEditor::Bool = false)
 	for textBox in this.scene.textBoxes
         JulGame.initialize(textBox)
 	end
-	for screenButton in this.scene.screenButtons
-        JulGame.initialize(screenButton)
-	end
 
 	this.lastMousePosition = Math.Vector2(0, 0)
 	this.panCounter = Math.Vector2f(0, 0)
@@ -476,25 +473,11 @@ function change_scene(sceneFileName::String)
         JulGame.destroy(textBox)
 	end
 	
-	persistentScreenButtons = []
-	# delete all screen buttons
-	for screenButton in MAIN.scene.screenButtons
-		if screenButton.persistentBetweenScenes
-			#println("Persistent screenButton: ", screenButton.name)
-			push!(persistentScreenButtons, screenButton)
-			skipcount += 1
-			continue
-		end
-
-		screenButton.destroy()
-	end
-	
 	#load new scene 
 	camera = MAIN.scene.camera
 	MAIN.scene = Scene()
 	MAIN.scene.entities = persistentEntities
 	MAIN.scene.textBoxes = persistentTextBoxes
-	MAIN.scene.screenButtons = persistentScreenButtons
 	MAIN.scene.camera = camera
 	MAIN.level.scene = sceneFileName
 end
@@ -804,10 +787,6 @@ function GameLoop(this::Main, startTime::Ref{UInt64} = Ref(UInt64(0)), lastPhysi
 			#endregion ============= Rendering
 
 			#region ============= UI
-			for screenButton in this.scene.screenButtons
-				JulGame.render(screenButton)
-			end
-
 			for textBox in this.scene.textBoxes
                 JulGame.render(textBox, DEBUG)
 			end

--- a/src/Scene.jl
+++ b/src/Scene.jl
@@ -4,7 +4,7 @@
     entities::Vector{Any}
     rigidbodies::Vector{Any}
     screenButtons::Vector{Any}
-    textBoxes::Vector{Any}
+    uiElements::Vector{Any}
 
     function Scene()
         this = new()
@@ -14,7 +14,7 @@
         this.entities = []
         this.rigidbodies = []
         this.screenButtons = []
-        this.textBoxes = []
+        this.uiElements = []
 
         return this
     end

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -60,7 +60,8 @@ module SceneBuilderModule
             init = init,
             changeScene = change_scene,
             createNewEntity = create_new_entity,
-            createNewTextBox = create_new_text_box
+            createNewTextBox = create_new_text_box,
+            createNewScreenButton = create_new_screen_button
         )
         deprecated_get_property(method_props, this, s)
     end
@@ -221,6 +222,15 @@ module SceneBuilderModule
         end 
     end
 
+    """
+    create_new_entity(this::Scene)
+
+    Create a new entity and add it to the scene.
+
+    # Arguments
+    - `this::Scene`: The scene object to which the entity will be added.
+
+    """
     function create_new_entity(this::Scene)
         push!(MAIN.scene.entities, Entity("New entity"))
     end
@@ -228,6 +238,13 @@ module SceneBuilderModule
     function create_new_text_box(this::Scene)
         textBox = TextBox("TextBox", "", 40, Vector2(0, 200), "TextBox", true, true)
         JulGame.initialize(textBox)
+        push!(MAIN.scene.textBoxes, textBox)
+    end
+    
+    function create_new_screen_button(this::Scene)
+        screenButton = ScreenButton("ButtonUp.png", "ButtonDown.png", Vector2(256, 64), Vector2(0, 0), joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), "test")
+        JulGame.initialize(screenButton)
+        push!(MAIN.scene.screenButtons, textBox)
         push!(MAIN.scene.textBoxes, textBox)
     end
 end

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -5,6 +5,7 @@ module SceneBuilderModule
     using ...EntityModule
     using ...RigidbodyModule
     using ...TextBoxModule
+    using ...ScreenButtonModule
     using ..SceneReaderModule
     import ...JulGame: deprecated_get_property
 
@@ -68,7 +69,7 @@ module SceneBuilderModule
 
     
 
-    function init(this::Scene, windowName::String = "Game", isUsingEditor = false, dimensions::Vector2 = Vector2(800, 800), camDimensions::Vector2 = Vector2(800,800), isResizable::Bool = true, zoom::Float64 = 1.0, autoScaleZoom::Bool = true, targetFrameRate = 60.0, globals = []; isNewEditor = false)
+    function init(this::Scene, windowName::String = "Game", isUsingEditor = false, size::Vector2 = Vector2(800, 800), camSize::Vector2 = Vector2(800,800), isResizable::Bool = true, zoom::Float64 = 1.0, autoScaleZoom::Bool = true, targetFrameRate = 60.0, globals = []; isNewEditor = false)
         #file loading
         if autoScaleZoom 
             zoom = 1.0
@@ -81,18 +82,18 @@ module SceneBuilderModule
         MAIN.targetFrameRate = targetFrameRate
         scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
         MAIN.scene.entities = scene[1]
-        MAIN.scene.textBoxes = scene[2]
-        if dimensions.x < camDimensions.x && dimensions.x > 0
-            camDimensions = Vector2(dimensions.x, camDimensions.y)
+        MAIN.scene.uiElements = scene[2]
+        if size.x < camSize.x && size.x > 0
+            camSize = Vector2(size.x, camSize.y)
         end
-        if dimensions.y < camDimensions.y && dimensions.y > 0
-            camDimensions = Vector2(camDimensions.x, dimensions.y)
+        if size.y < camSize.y && size.y > 0
+            camSize = Vector2(camSize.x, size.y)
         end
-        MAIN.scene.camera = Camera(camDimensions, Vector2f(),Vector2f(), C_NULL)
+        MAIN.scene.camera = Camera(camSize, Vector2f(),Vector2f(), C_NULL)
         
-        for textBox in MAIN.scene.textBoxes
-            if textBox.isWorldEntity
-                textBox.centerText()
+        for uiElement in MAIN.scene.uiElements
+            if "$(typeof(uiElement))" == "JulGame.UI.TextBoxModule.Textbox" && uiElement.isWorldEntity
+                uiElement.centerText()
             end
         end
 
@@ -144,7 +145,7 @@ module SceneBuilderModule
         end
 
         MAIN.assets = joinpath(BasePath, "assets")
-        MAIN.init(isUsingEditor, dimensions, isResizable, autoScaleZoom, isNewEditor)
+        MAIN.init(isUsingEditor, size, isResizable, autoScaleZoom, isNewEditor)
 
         return MAIN
     end
@@ -159,11 +160,11 @@ module SceneBuilderModule
             push!(MAIN.scene.entities, entity)
         end
 
-        MAIN.scene.textBoxes = scene[2]
+        MAIN.scene.uiElements = scene[2]
 
-        for textBox in MAIN.scene.textBoxes
-            if textBox.isWorldEntity
-                textBox.centerText()
+        for uiElement in MAIN.scene.uiElements
+            if "$(typeof(uiElement))" == "JulGame.UI.TextBoxModule.Textbox" && uiElement.isWorldEntity
+                uiElement.centerText()
             end
         end
 
@@ -238,13 +239,13 @@ module SceneBuilderModule
     function create_new_text_box(this::Scene)
         textBox = TextBox("TextBox", "", 40, Vector2(0, 200), "TextBox", true, true)
         JulGame.initialize(textBox)
-        push!(MAIN.scene.textBoxes, textBox)
+        push!(MAIN.scene.uiElements, textBox)
     end
     
     function create_new_screen_button(this::Scene)
-        screenButton = ScreenButton("ButtonUp.png", "ButtonDown.png", Vector2(256, 64), Vector2(0, 0), joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), "test")
+        screenButton = ScreenButton("name", "ButtonUp.png", "ButtonDown.png", Vector2(256, 64), Vector2(0, 0), joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), "test")
         JulGame.initialize(screenButton)
-        push!(MAIN.scene.screenButtons, textBox)
-        push!(MAIN.scene.textBoxes, textBox)
+        push!(MAIN.scene.screenButtons, screenButton)
+        push!(MAIN.scene.uiElements, screenButton)
     end
 end

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -10,6 +10,7 @@ module SceneReaderModule
     using ...SoundSourceModule
     using ...SpriteModule
     using ...UI.TextBoxModule
+    using ...UI.ScreenButtonModule
     using ...TransformModule
 
 

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -24,7 +24,7 @@ module SceneReaderModule
 
             json = JSON3.read(entitiesJson)
             entities =[]
-            textBoxes = []
+            uiElements = []
             res = []
     
             for entity in json.Entities
@@ -76,10 +76,10 @@ module SceneReaderModule
                 
                 push!(entities, newEntity)
             end
-            textBoxes = deserializeTextBoxes(json.TextBoxes)
+            uiElements = deserializeUIElements(json.UIElements)
     
             push!(res, entities)
-            push!(res, textBoxes)
+            push!(res, uiElements)
             return res
         catch e 
             println(e)
@@ -88,13 +88,19 @@ module SceneReaderModule
         end
     end
 
-    function deserializeTextBoxes(jsonTextBoxes)
+    function deserializeUIElements(jsonUIElements)
         res = []
 
-        for textBox in jsonTextBoxes
+        for uiElement in jsonUIElements
             try
-                newTextBox = TextBox(textBox.name, textBox.fontPath, textBox.fontSize, Vector2(textBox.position.x, textBox.position.y), textBox.text, textBox.isCenteredX, textBox.isCenteredY)        
-                push!(res, newTextBox)
+                newUIElement = nothing
+                if uiElement.type == "TextBox"
+                    newUIElement = TextBox(uiElement.name, uiElement.fontPath, uiElement.fontSize, Vector2(uiElement.position.x, uiElement.position.y), uiElement.text, uiElement.isCenteredX, uiElement.isCenteredY)        
+                else
+                    newUIElement = ScreenButton(uiElement.name, uiElement.buttonUpSpritePath, uiElement.buttonDownSpritePath, Vector2(uiElement.size.x, uiElement.size.y), Vector2(uiElement.position.x, uiElement.position.y), uiElement.fontPath, uiElement.text, Vector2(uiElement.textOffset.x, uiElement.textOffset.y))
+                end
+                
+                push!(res, newUIElement)
             catch e 
                 println(e)
 				Base.show_backtrace(stdout, catch_backtrace())

--- a/src/SceneManagement/SceneWriter.jl
+++ b/src/SceneManagement/SceneWriter.jl
@@ -21,30 +21,45 @@ module SceneWriterModule
         
         count = 1
         for entity in entities
-        push!(entitiesDict, Dict("id" => count, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
-        count += 1
+            push!(entitiesDict, Dict("id" => count, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
+            count += 1
         end
+
         count = 1
         for uiElement in uiElements
             if "$(typeof(uiElement))" == "JulGame.UI.ScreenButtonModule.ScreenButton"
-                println("skipping screenButton")
-                continue
+                push!(uiElementsDict, Dict(
+                    "id" => count, 
+                    # TODO: "alpha" => uiElement.alpha, 
+                    "buttonDownSpritePath" => normalize_path(uiElement.buttonDownSpritePath), 
+                    "buttonUpSpritePath" => normalize_path(uiElement.buttonUpSpritePath), 
+                    "fontPath" => normalize_path(uiElement.fontPath), 
+                    # TODO: "fontSize" => uiElement.fontSize, 
+                    "name" => uiElement.name,
+                    "persistentBetweenScenes" => uiElement.persistentBetweenScenes,
+                    "position" => Dict("x" => uiElement.position.x, "y" => uiElement.position.y),
+                    "size" => Dict("x" => uiElement.size.x, "y" => uiElement.size.y),
+                    "text" => uiElement.text,
+                    "textOffset" => Dict("x" => uiElement.textOffset.x, "y" => uiElement.textOffset.y),
+                    "type" => "ScreenButton"
+                    ))
+            else
+                push!(uiElementsDict, Dict(
+                    "id" => count, 
+                    "alpha" => uiElement.alpha, 
+                    "fontPath" => normalize_path(uiElement.fontPath), 
+                    "fontSize" => uiElement.fontSize, 
+                    "isCenteredX" => uiElement.isCenteredX,
+                    "isCenteredY" => uiElement.isCenteredY,
+                    "isWorldEntity" => uiElement.isWorldEntity,
+                    "name" => uiElement.name,
+                    "persistentBetweenScenes" => uiElement.persistentBetweenScenes,
+                    "position" => Dict("x" => uiElement.position.x, "y" => uiElement.position.y),
+                    "size" => Dict("x" => uiElement.size.x, "y" => uiElement.size.y),
+                    "text" => uiElement.text,
+                    "type" => "TextBox"
+                    ))
             end
-            push!(uiElementsDict, Dict(
-                "id" => count, 
-                "alpha" => uiElement.alpha, 
-                "fontPath" => normalize_path(uiElement.fontPath), 
-                "fontSize" => uiElement.fontSize, 
-                "isCenteredX" => uiElement.isCenteredX,
-                "isCenteredY" => uiElement.isCenteredY,
-                "isWorldEntity" => uiElement.isWorldEntity,
-                "name" => uiElement.name,
-                "persistentBetweenScenes" => uiElement.persistentBetweenScenes,
-                "position" => Dict("x" => uiElement.position.x, "y" => uiElement.position.y),
-                "size" => Dict("x" => uiElement.size.x, "y" => uiElement.size.y),
-                "text" => uiElement.text,
-                "type" => "TextBox"
-                ))
             count += 1
         end
         entitiesJson = Dict( 

--- a/src/SceneManagement/SceneWriter.jl
+++ b/src/SceneManagement/SceneWriter.jl
@@ -1,50 +1,55 @@
 module SceneWriterModule
     using JSON3
-
+    
     export serialize_entities
     """
-        serialize_entities(entities::Array, textBoxes::Array, projectPath, sceneName)
+        serialize_entities(entities::Array, uiElements::Array, projectPath, sceneName)
 
     Serialize the entities and text boxes into a JSON file.
 
     # Arguments
     - `entities::Array`: An array of entities to be serialized.
-    - `textBoxes::Array`: An array of text boxes to be serialized.
+    - `uiElements::Array`: An array of text boxes to be serialized.
     - `projectPath`: The path to the project directory.
     - `sceneName`: The name of the scene.
 
     """
-    function serialize_entities(entities::Array, textBoxes::Array, projectPath, sceneName)
+    function serialize_entities(entities::Array, uiElements::Array, projectPath, sceneName)
         
         entitiesDict = []
-        textBoxesDict = []
-
+        uiElementsDict = []
+        
         count = 1
         for entity in entities
         push!(entitiesDict, Dict("id" => count, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
         count += 1
         end
         count = 1
-        for textBox in textBoxes
-        push!(textBoxesDict, Dict(
-            "id" => count, 
-            "alpha" => textBox.alpha, 
-            "fontPath" => normalize_path(textBox.fontPath), 
-            "fontSize" => textBox.fontSize, 
-            "isCenteredX" => textBox.isCenteredX,
-            "isCenteredY" => textBox.isCenteredY,
-            "isWorldEntity" => textBox.isWorldEntity,
-            "name" => textBox.name,
-            "persistentBetweenScenes" => textBox.persistentBetweenScenes,
-            "position" => Dict("x" => textBox.position.x, "y" => textBox.position.y),
-            "size" => Dict("x" => textBox.size.x, "y" => textBox.size.y),
-            "text" => textBox.text
-            ))
-        count += 1
+        for uiElement in uiElements
+            if "$(typeof(uiElement))" == "JulGame.UI.ScreenButtonModule.ScreenButton"
+                println("skipping screenButton")
+                continue
+            end
+            push!(uiElementsDict, Dict(
+                "id" => count, 
+                "alpha" => uiElement.alpha, 
+                "fontPath" => normalize_path(uiElement.fontPath), 
+                "fontSize" => uiElement.fontSize, 
+                "isCenteredX" => uiElement.isCenteredX,
+                "isCenteredY" => uiElement.isCenteredY,
+                "isWorldEntity" => uiElement.isWorldEntity,
+                "name" => uiElement.name,
+                "persistentBetweenScenes" => uiElement.persistentBetweenScenes,
+                "position" => Dict("x" => uiElement.position.x, "y" => uiElement.position.y),
+                "size" => Dict("x" => uiElement.size.x, "y" => uiElement.size.y),
+                "text" => uiElement.text,
+                "type" => "TextBox"
+                ))
+            count += 1
         end
         entitiesJson = Dict( 
             "Entities" => entitiesDict,
-            "TextBoxes" => textBoxesDict
+            "UIElements" => uiElementsDict
             )
         try
             println("writing to $(joinpath(projectPath, "scenes", "$(sceneName)"))")

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -55,7 +55,7 @@ module ScreenButtonModule
         deprecated_get_property(method_props, this, s)
     end
     
-    function UI.render(this::ScreenButton)
+    function UI.render(this::ScreenButton, debug=false)
         if !this.isInitialized
             this.initialize()
         end

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -13,27 +13,29 @@ module ScreenButtonModule
         #TODO: add buttonHoverSprite/Color Mod 
         buttonUpSprite
         buttonUpTexture
-        dimensions
         fontPath::Union{String, Ptr{Nothing}}
         isInitialized::Bool
         mouseOverSprite
+        name::String
         persistentBetweenScenes::Bool
         position::Math.Vector2
+        size::Math.Vector2
         text::String
         textOffset::Math.Vector2
         textSize::Math.Vector2
         textTexture
 
-        function ScreenButton(buttonUpSpritePath::String, buttonDownSpritePath::String, dimensions::Math.Vector2, position::Math.Vector2, fontPath::Union{String, Ptr{Nothing}} = C_NULL, text::String="", textOffset::Math.Vector2=Math.Vector2(0,0); isCreatedInEditor::Bool=false)
+        function ScreenButton(name::String, buttonUpSpritePath::String, buttonDownSpritePath::String, size::Math.Vector2, position::Math.Vector2, fontPath::Union{String, Ptr{Nothing}} = C_NULL, text::String="", textOffset::Math.Vector2=Math.Vector2(0,0); isCreatedInEditor::Bool=false)
             this = new()
             
             this.buttonDownSprite = CallSDLFunction(SDL2.IMG_Load, joinpath(JulGame.BasePath, "assets", "images", buttonDownSpritePath))
             this.buttonUpSprite = CallSDLFunction(SDL2.IMG_Load, joinpath(JulGame.BasePath, "assets", "images", buttonUpSpritePath))
             this.clickEvents = []
             this.currentTexture = C_NULL
-            this.dimensions = dimensions
+            this.size = size
             this.fontPath = fontPath
             this.mouseOverSprite = false
+            this.name = name
             this.position = position
             this.text = text
             this.textOffset = textOffset
@@ -71,7 +73,7 @@ module ScreenButtonModule
             JulGame.Renderer, 
             this.currentTexture, 
             C_NULL, 
-            Ref(SDL2.SDL_FRect(this.position.x, this.position.y, this.dimensions.x,this.dimensions.y)), 
+            Ref(SDL2.SDL_FRect(this.position.x, this.position.y, this.size.x,this.size.y)), 
             0.0, 
             C_NULL, 
             SDL2.SDL_FLIP_NONE) == 0 "error rendering image: $(unsafe_string(SDL2.SDL_GetError()))"

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -57,6 +57,8 @@ module ScreenButtonModule
             initialize = UI.initialize,
             addClickEvent = UI.add_click_event,
             handleEvent = UI.handle_event,
+            setVector2Value = UI.set_vector2_value,
+            loadSprite = UI.load_button_sprite_editor,
             destroy = UI.destroy
         )
         deprecated_get_property(method_props, this, s)
@@ -72,8 +74,11 @@ module ScreenButtonModule
         end
 
         if !this.mouseOverSprite && this.currentTexture == this.buttonDownTexture
-            this.currentTexture = this.buttonUpTexture
+            #TODO: this.currentTexture = this.buttonUpTexture
         end    
+        if this.currentTexture == C_NULL || this.textTexture == C_NULL || this.currentTexture === nothing || this.textTexture === nothing
+            return
+        end
         @assert SDL2.SDL_RenderCopyExF(
             JulGame.Renderer, 
             this.currentTexture, 
@@ -104,8 +109,29 @@ module ScreenButtonModule
         this.isInitialized = true
     end
 
+    function UI.load_button_sprite_editor(this::ScreenButton, path::String, up::Bool)
+        sprite = CallSDLFunction(SDL2.IMG_Load, joinpath(JulGame.BasePath, "assets", "images", path))
+        texture = CallSDLFunction(SDL2.SDL_CreateTextureFromSurface, JulGame.Renderer, sprite)
+        if up
+            this.buttonUpSpritePath = path
+            this.buttonUpSprite = sprite
+            this.buttonUpTexture = texture
+        else
+            this.buttonDownSpritePath = path
+            this.buttonDownSprite = sprite
+            this.buttonDownTexture = texture
+        end
+
+        this.currentTexture = texture
+    end
+
     function UI.add_click_event(this::ScreenButton, event)
         push!(this.clickEvents, event)
+    end
+
+    function UI.set_vector2_value(this::ScreenButton, field, x, y)
+        setfield!(this, field, Math.Vector2(x,y))
+        # println("set $(field) to $(getfield(this, field))")
     end
 
     function UI.handle_event(this::ScreenButton, evt, x, y)

--- a/src/UI/ScreenButton.jl
+++ b/src/UI/ScreenButton.jl
@@ -6,12 +6,15 @@ module ScreenButtonModule
 
     export ScreenButton
     mutable struct ScreenButton
+        alpha
         clickEvents::Vector{Function}
         currentTexture
         buttonDownSprite
+        buttonDownSpritePath::String
         buttonDownTexture
         #TODO: add buttonHoverSprite/Color Mod 
         buttonUpSprite
+        buttonUpSpritePath::String
         buttonUpTexture
         fontPath::Union{String, Ptr{Nothing}}
         isInitialized::Bool
@@ -25,9 +28,11 @@ module ScreenButtonModule
         textSize::Math.Vector2
         textTexture
 
-        function ScreenButton(name::String, buttonUpSpritePath::String, buttonDownSpritePath::String, size::Math.Vector2, position::Math.Vector2, fontPath::Union{String, Ptr{Nothing}} = C_NULL, text::String="", textOffset::Math.Vector2=Math.Vector2(0,0); isCreatedInEditor::Bool=false)
+        function ScreenButton(name::String, buttonUpSpritePath::String, buttonDownSpritePath::String, size::Math.Vector2, position::Math.Vector2, fontPath::Union{String, Ptr{Nothing}} = C_NULL, text::String="", textOffset::Math.Vector2=Math.Vector2(0,0))
             this = new()
             
+            this.buttonDownSpritePath = buttonDownSpritePath
+            this.buttonUpSpritePath = buttonUpSpritePath
             this.buttonDownSprite = CallSDLFunction(SDL2.IMG_Load, joinpath(JulGame.BasePath, "assets", "images", buttonDownSpritePath))
             this.buttonUpSprite = CallSDLFunction(SDL2.IMG_Load, joinpath(JulGame.BasePath, "assets", "images", buttonUpSpritePath))
             this.clickEvents = []
@@ -78,7 +83,7 @@ module ScreenButtonModule
             C_NULL, 
             SDL2.SDL_FLIP_NONE) == 0 "error rendering image: $(unsafe_string(SDL2.SDL_GetError()))"
 
-        @assert SDL2.SDL_RenderCopyF(JulGame.Renderer, this.textTexture, C_NULL, Ref(SDL2.SDL_FRect(this.position.x + this.textOffset.x, this.position.y + this.textOffset.y,this.textSize.x,this.textSize.y))) == 0 "error rendering button text: $(unsafe_string(SDL2.SDL_GetError()))"
+        # @assert SDL2.SDL_RenderCopyF(JulGame.Renderer, this.textTexture, C_NULL, Ref(SDL2.SDL_FRect(this.position.x + this.textOffset.x, this.position.y + this.textOffset.y,this.textSize.x,this.textSize.y))) == 0 "error rendering button text: $(unsafe_string(SDL2.SDL_GetError()))"
     end
 
     function UI.initialize(this::ScreenButton)

--- a/src/UI/TextBox.jl
+++ b/src/UI/TextBox.jl
@@ -141,7 +141,7 @@ module TextBoxModule
 
     function UI.set_vector2_value(this::TextBox, field, x, y)
         setfield!(this, field, Math.Vector2(x,y))
-        println("set $(field) to $(getfield(this, field))")
+        # println("set $(field) to $(getfield(this, field))")
     end
 
     function UI.set_color(this::TextBox, r,g,b)

--- a/src/UI/TextBox.jl
+++ b/src/UI/TextBox.jl
@@ -150,10 +150,10 @@ module TextBoxModule
 
     function UI.center_text(this::TextBox)
         if this.isCenteredX
-            this.position = Math.Vector2(max(MAIN.scene.camera.dimensions.x/2 - this.size.x/2, 0), this.position.y)
+            this.position = Math.Vector2(max(MAIN.scene.camera.size.x/2 - this.size.x/2, 0), this.position.y)
         end
         if this.isCenteredY
-            this.position = Math.Vector2(this.position.x, max(MAIN.scene.camera.dimensions.y/2 - this.size.y/2, 0))
+            this.position = Math.Vector2(this.position.x, max(MAIN.scene.camera.size.y/2 - this.size.y/2, 0))
         end
     end
 

--- a/src/UI/UI.jl
+++ b/src/UI/UI.jl
@@ -6,6 +6,7 @@ module UI
         destroy,
         handle_event,
         initialize,
+        load_button_sprite_editor,
         load_font,
         render,
         set_color,

--- a/src/editor/JulGameEditor/Components/ComponentInputs.jl
+++ b/src/editor/JulGameEditor/Components/ComponentInputs.jl
@@ -6,6 +6,7 @@ using JulGame.Math
 using JulGame.UI
 
 include("TextBoxFields.jl")
+include("ScreenButtonFields.jl")
 
 
 """
@@ -305,6 +306,38 @@ function show_textbox_fields(textbox)
             CImGui.Button("Load Font") && (UI.load_font(textbox, joinpath(pwd()), joinpath("Fonts", "FiraCode", "ttf", "FiraCode-Regular.ttf")))
         else 
             show_textbox_fields(textbox, field)
+        end  
+    end
+end
+
+function show_screenbutton_fields(screenButton)
+    for field in fieldnames(typeof(screenButton))
+        fieldString = "$(field)"
+
+        # TODO: if fieldString == "fontPath" || 
+        if fieldString == "buttonUpSpritePath" || fieldString == "buttonDownSpritePath"
+            buf = "$(getfield(screenButton, Symbol(fieldString)))"*"\0"^(64)
+            CImGui.InputText("$(fieldString) Path Input", buf, length(buf))
+            currentTextInScreenButton = ""
+            for characterIndex = eachindex(buf)
+                if Int32(buf[characterIndex]) == 0 
+                    if characterIndex != 1
+                        currentTextInScreenButton = String(SubString(buf, 1, characterIndex-1))
+                    end
+                    break
+                end
+            end
+            setfield!(screenButton, Symbol(fieldString), currentTextInScreenButton)
+
+            if fieldString == "fontPath"
+                # TODO: CImGui.Button("Load Font") && (UI.load_font(screenButton, joinpath(pwd()), joinpath("Fonts", "FiraCode", "ttf", "FiraCode-Regular.ttf")))
+            elseif fieldString == "buttonUpSpritePath"
+                CImGui.Button("Load Button Up Sprite") && (screenButton.loadSprite(currentTextInScreenButton, true))
+            elseif fieldString == "buttonDownSpritePath"
+                CImGui.Button("Load Button Down Sprite") && (screenButton.loadSprite(currentTextInScreenButton, false))
+            end
+        else 
+            show_screenbutton_fields(screenButton, field)
         end  
     end
 end

--- a/src/editor/JulGameEditor/Components/ScreenButtonFields.jl
+++ b/src/editor/JulGameEditor/Components/ScreenButtonFields.jl
@@ -1,0 +1,71 @@
+function show_screenbutton_fields(selectedScreenButton, screenButtonField)
+    fieldName = getFieldName(screenButtonField)
+    unusedFields = ["alpha","clickEvents", "currentTexture", "buttonDownSprite", "buttonDownSpritePath", "buttonDownTexture", "buttonUpSprite", "buttonUpSpritePath", "buttonUpTexture", "fontPath", "isInitialized", "mouseOverSprite", "textTexture"]
+    # TODO: 
+    push!(unusedFields, "text")
+    if fieldName in unusedFields
+        return
+    end
+    Value = getfield(selectedScreenButton, screenButtonField)
+
+    if fieldName == "text" || fieldName == "name" 
+        buf = "$(Value)"*"\0"^(64)
+        CImGui.InputText("$(screenButtonField)", buf, length(buf))
+        currentTextInTextBox = ""
+        for characterIndex = eachindex(buf)
+            if Int32(buf[characterIndex]) == 0 
+                if characterIndex != 1
+                    currentTextInTextBox = String(SubString(buf, 1, characterIndex-1))
+                end
+                break
+            end
+        end
+        setfield!(selectedScreenButton, screenButtonField, currentTextInTextBox)
+        
+        if currentTextInTextBox != Value
+            # JulGame.update_text(selectedScreenButton, selectedScreenButton.text)
+        end
+
+    elseif fieldName == "alpha"
+        x = Cint(Value)
+        @c CImGui.SliderInt("$(screenButtonField)", &x, 0, 255)
+        setfield!(selectedScreenButton, screenButtonField, convert(Int32, round(x)))
+
+        if x != Value
+            # JulGame.update_text(selectedScreenButton, selectedScreenButton.text)
+        end
+
+    elseif fieldName == "color"
+        x = Cfloat(Value.r)
+        y = Cfloat(Value.g)
+        z = Cfloat(Value.b)
+        w = Cfloat(Value.a)
+        @c CImGui.ColorEdit4("$(screenButtonField)", &x, &y, &z, &w)
+        setfield!(selectedScreenButton, screenButtonField, Color(convert(Int32, round(x)), convert(Int32, round(y)), convert(Int32, round(z)), convert(Int32, round(w))))
+
+        if x != Value.r || y != Value.g || z != Value.b || w != Value.a
+            # JulGame.update_text(selectedScreenButton, selectedScreenButton.text)
+        end
+    elseif fieldName == "position" || fieldName == "size"
+        x = Cint(Value.x)
+        y = Cint(Value.y)
+        @c CImGui.InputInt("$(screenButtonField) x", &x, 1)
+        @c CImGui.InputInt("$(screenButtonField) y", &y, 1)
+        
+        if x != Value.x || y != Value.y
+            selectedScreenButton.setVector2Value(screenButtonField, convert(Float64, x), convert(Float64, y))
+            # JulGame.update_text(selectedScreenButton, selectedScreenButton.text)
+        end
+    elseif fieldName == "autoSizeText" || fieldName == "isCentered"
+        @c CImGui.Checkbox("$(screenButtonField)", &Value)
+
+        if Value != getfield(selectedScreenButton, screenButtonField)
+            setfield!(selectedScreenButton, screenButtonField, Value)
+            # JulGame.update_text(selectedScreenButton, selectedScreenButton.text)
+        end
+    end
+end
+
+function getFieldName(field)
+    return "$(field)"
+end

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -310,7 +310,12 @@ module Editor
                                 if length(currentSceneMain.scene.uiElements) < uiElementIndex
                                     break
                                 end
-                                show_textbox_fields(currentSceneMain.scene.uiElements[uiElementIndex])
+                                if contains("$(typeof(currentSceneMain.scene.uiElements[uiElementIndex]))", "TextBox")
+                                    show_textbox_fields(currentSceneMain.scene.uiElements[uiElementIndex])
+                                else
+                                    println("$(typeof(currentSceneMain.scene.uiElements[uiElementIndex]))")
+                                    println("UI Element type not supported yet.")
+                                end
 
                                 # CImGui.Separator()
                                 # if CImGui.Button("Duplicate") 

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -61,7 +61,7 @@ module Editor
                     ################################# MAIN MENU BAR
                     events = []
                     if currentSceneMain !== nothing
-                        push!(events, save_scene_event(currentSceneMain.scene.entities, currentSceneMain.scene.textBoxes, currentSelectedProjectPath, String(currentSceneName)))
+                        push!(events, save_scene_event(currentSceneMain.scene.entities, currentSceneMain.scene.uiElements, currentSelectedProjectPath, String(currentSceneName)))
                     end
                     push!(events, select_project_event(currentSceneMain, scenesLoadedFromFolder))
                     show_main_menu_bar(events)
@@ -222,19 +222,19 @@ module Editor
                             end
                             CImGui.Unindent(CImGui.GetTreeNodeToLabelSpacing())
 
-                            if length(hierarchyUISelections) == 0 || length(hierarchyUISelections) != length(currentSceneMain.scene.textBoxes) # || updateUISelectionsBasedOnFilter
-                                hierarchyUISelections=fill(false, length(currentSceneMain.scene.textBoxes))
+                            if length(hierarchyUISelections) == 0 || length(hierarchyUISelections) != length(currentSceneMain.scene.uiElements) # || updateUISelectionsBasedOnFilter
+                                hierarchyUISelections=fill(false, length(currentSceneMain.scene.uiElements))
                             end
 
-                            for n = eachindex(currentSceneMain.scene.textBoxes)
+                            for n = eachindex(currentSceneMain.scene.uiElements)
                                 CImGui.PushID(n)
-                                buf = "$(n): $(currentSceneMain.scene.textBoxes[n].name)"
+                                buf = "$(n): $(currentSceneMain.scene.uiElements[n].name)"
                                 if CImGui.Selectable(buf, hierarchyUISelections[n])
                                     # clear selection when CTRL is not held
                                     !unsafe_load(CImGui.GetIO().KeyCtrl) && fill!(hierarchyUISelections, false)
                                     hierarchyUISelections[n] ⊻= 1
                                     uiSelected = true
-                                    # currentSceneMain.selectedEntity = currentSceneMain.scene.textBoxes[n]
+                                    # currentSceneMain.selectedEntity = currentSceneMain.scene.uiElements[n]
                                 end
                                 CImGui.PopID()
 
@@ -301,27 +301,27 @@ module Editor
                             if hierarchyUISelections[uiElementIndex] # || currentSceneMain.selectedEntity == filteredEntities[entityIndex]
                                 CImGui.PushID("AddMenu")
                                 if CImGui.BeginMenu("Add")
-                                    ShowEntityContextMenu(currentSceneMain.scene.textBoxes[uiElementIndex])
+                                    ShowEntityContextMenu(currentSceneMain.scene.uiElements[uiElementIndex])
                                     CImGui.EndMenu()
                                 end
                                 CImGui.PopID()
                                 CImGui.Separator()
 
-                                if length(currentSceneMain.scene.textBoxes) < uiElementIndex
+                                if length(currentSceneMain.scene.uiElements) < uiElementIndex
                                     break
                                 end
-                                show_textbox_fields(currentSceneMain.scene.textBoxes[uiElementIndex])
+                                show_textbox_fields(currentSceneMain.scene.uiElements[uiElementIndex])
 
                                 # CImGui.Separator()
                                 # if CImGui.Button("Duplicate") 
-                                #     push!(currentSceneMain.scene.textBoxes, deepcopy(currentSceneMain.scene.textBoxes[uiElementIndex]))
+                                #     push!(currentSceneMain.scene.uiElements, deepcopy(currentSceneMain.scene.uiElements[uiElementIndex]))
                                 #     # TODO: switch to duplicated entity
                                 # end
 
                                 CImGui.Separator()
                                 CImGui.Text("Delete UI Element: NO CONFIRMATION")
                                 if CImGui.Button("Delete")
-                                    #MainLoop.DestroyEntity(currentSceneMain.scene.textBoxes[uiElementIndex])
+                                    #MainLoop.DestroyEntity(currentSceneMain.scene.uiElements[uiElementIndex])
                                     break
                                 end
                                 
@@ -470,22 +470,22 @@ module Editor
 
   
     """
-        save_scene_event(entities, textBoxes, projectPath::String, sceneName::String)
+        save_scene_event(entities, uiElements, projectPath::String, sceneName::String)
 
     Save the scene by serializing the entities and text boxes to a file.
 
     # Arguments
     - `entities`: The entities to be serialized.
-    - `textBoxes`: The text boxes to be serialized.
+    - `uiElements`: The text boxes to be serialized.
     - `projectPath`: The path of the project.
     - `sceneName`: The name of the scene.
 
     # Returns
     - `event`: The event object representing the save scene event.
     """
-    function save_scene_event(entities, textBoxes, projectPath::String, sceneName::String)
+    function save_scene_event(entities, uiElements, projectPath::String, sceneName::String)
         event = @event begin
-            SceneWriterModule.serialize_entities(entities, textBoxes, projectPath, "$(sceneName)")
+            SceneWriterModule.serialize_entities(entities, uiElements, projectPath, "$(sceneName)")
         end
 
         return event

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -209,10 +209,11 @@ module Editor
                             if CImGui.BeginMenu("Add") # TODO: Move to own file as a function
                                 CImGui.MenuItem("Add", C_NULL, false, false)
                                 if CImGui.BeginMenu("New")
-                                    if CImGui.MenuItem("TextBox")
+                                    if CImGui.MenuItem("TextBox---")
                                         currentSceneMain.createNewTextBox() 
                                     end
-                                    if CImGui.MenuItem("Screen Button")
+                                    if CImGui.MenuItem("Screen Button---")
+                                        currentSceneMain.createNewScreenButton()
                                     end
                                     
                                     CImGui.EndMenu()

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -310,11 +310,11 @@ module Editor
                                 if length(currentSceneMain.scene.uiElements) < uiElementIndex
                                     break
                                 end
+                                
                                 if contains("$(typeof(currentSceneMain.scene.uiElements[uiElementIndex]))", "TextBox")
                                     show_textbox_fields(currentSceneMain.scene.uiElements[uiElementIndex])
                                 else
-                                    println("$(typeof(currentSceneMain.scene.uiElements[uiElementIndex]))")
-                                    println("UI Element type not supported yet.")
+                                    show_screenbutton_fields(currentSceneMain.scene.uiElements[uiElementIndex])
                                 end
 
                                 # CImGui.Separator()

--- a/src/editor/JulGameEditor/src/imgui.ini
+++ b/src/editor/JulGameEditor/src/imgui.ini
@@ -1,11 +1,11 @@
 [Window][DockSpaceViewport_11111111]
 Pos=0,19
-Size=1920,1061
+Size=1920,989
 Collapsed=0
 
 [Window][Hierarchy]
 Pos=0,19
-Size=475,721
+Size=475,672
 Collapsed=0
 DockId=0x00000009,0
 
@@ -21,14 +21,14 @@ Collapsed=0
 DockId=0x00000008,0
 
 [Window][Debug]
-Pos=477,658
+Pos=477,586
 Size=867,422
 Collapsed=0
 DockId=0x00000006,0
 
 [Window][Scene]
 Pos=477,19
-Size=867,637
+Size=867,565
 Collapsed=0
 DockId=0x00000005,0
 
@@ -45,14 +45,14 @@ Collapsed=0
 DockId=0x00000007,0
 
 [Window][Controls]
-Pos=477,658
+Pos=477,586
 Size=867,422
 Collapsed=0
 DockId=0x00000006,1
 
 [Window][Dear ImGui Demo]
 Pos=1346,19
-Size=574,1061
+Size=574,989
 Collapsed=0
 DockId=0x0000000C,1
 
@@ -70,24 +70,24 @@ DockId=0x0000000C,3
 
 [Window][Project]
 Pos=1346,19
-Size=574,1061
+Size=574,989
 Collapsed=0
 DockId=0x0000000C,0
 
 [Window][Entity Inspector]
-Pos=0,742
-Size=475,338
+Pos=0,693
+Size=475,315
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][UI Inspector]
-Pos=0,742
-Size=475,338
+Pos=0,693
+Size=475,315
 Collapsed=0
 DockId=0x0000000A,1
 
 [Docking][Data]
-DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1920,1061 Split=X
+DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1920,989 Split=X
   DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=475,1061 Split=Y Selected=0x29EABFBD
     DockNode      ID=0x00000009 Parent=0x00000003 SizeRef=600,721 Selected=0x29EABFBD
     DockNode      ID=0x0000000A Parent=0x00000003 SizeRef=600,338 Selected=0xC7219E3D

--- a/src/editor/JulGameEditor/src/imgui.ini
+++ b/src/editor/JulGameEditor/src/imgui.ini
@@ -1,11 +1,11 @@
 [Window][DockSpaceViewport_11111111]
 Pos=0,19
-Size=1920,989
+Size=1920,1061
 Collapsed=0
 
 [Window][Hierarchy]
 Pos=0,19
-Size=475,672
+Size=475,721
 Collapsed=0
 DockId=0x00000009,0
 
@@ -21,14 +21,14 @@ Collapsed=0
 DockId=0x00000008,0
 
 [Window][Debug]
-Pos=477,586
+Pos=477,658
 Size=867,422
 Collapsed=0
 DockId=0x00000006,0
 
 [Window][Scene]
 Pos=477,19
-Size=867,565
+Size=867,637
 Collapsed=0
 DockId=0x00000005,0
 
@@ -45,14 +45,14 @@ Collapsed=0
 DockId=0x00000007,0
 
 [Window][Controls]
-Pos=477,586
+Pos=477,658
 Size=867,422
 Collapsed=0
 DockId=0x00000006,1
 
 [Window][Dear ImGui Demo]
 Pos=1346,19
-Size=574,989
+Size=574,1061
 Collapsed=0
 DockId=0x0000000C,1
 
@@ -70,24 +70,24 @@ DockId=0x0000000C,3
 
 [Window][Project]
 Pos=1346,19
-Size=574,989
+Size=574,1061
 Collapsed=0
 DockId=0x0000000C,0
 
 [Window][Entity Inspector]
-Pos=0,693
-Size=475,315
+Pos=0,742
+Size=475,338
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][UI Inspector]
-Pos=0,693
-Size=475,315
+Pos=0,742
+Size=475,338
 Collapsed=0
 DockId=0x0000000A,1
 
 [Docking][Data]
-DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1920,989 Split=X
+DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1920,1061 Split=X
   DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=475,1061 Split=Y Selected=0x29EABFBD
     DockNode      ID=0x00000009 Parent=0x00000003 SizeRef=600,721 Selected=0x29EABFBD
     DockNode      ID=0x0000000A Parent=0x00000003 SizeRef=600,338 Selected=0xC7219E3D

--- a/test/projects/ProfilingTest/Platformer/scripts/GameManager.jl
+++ b/test/projects/ProfilingTest/Platformer/scripts/GameManager.jl
@@ -50,7 +50,7 @@ function Base.getproperty(this::GameManager, s::Symbol)
             this.currentMusic = this.parent.createSoundSource(SoundSource(Int32(-1), true, this.soundBank[this.currentLevel], Int32(25)))
             this.currentMusic.toggleSound()
 
-            MAIN.scene.textBoxes[2].updateText(string(this.starCount))
+            MAIN.scene.uiElements[2].updateText(string(this.starCount))
         end
     elseif s == :update
         function(deltaTime)

--- a/test/projects/ProfilingTest/Platformer/scripts/PlayerMovement.jl
+++ b/test/projects/ProfilingTest/Platformer/scripts/PlayerMovement.jl
@@ -102,12 +102,12 @@ function Base.getproperty(this::PlayerMovement, s::Symbol)
                     MainLoop.change_scene("level_3.json")
                 else 
                     # you win text
-                    MAIN.scene.textBoxes[1].isCenteredX, MAIN.scene.textBoxes[1].isCenteredY = true, true
-                    MAIN.scene.textBoxes[1].updateText("You Win!")
-                    MAIN.scene.textBoxes[1].setColor(0,0,0)
+                    MAIN.scene.uiElements[1].isCenteredX, MAIN.scene.uiElements[1].isCenteredY = true, true
+                    MAIN.scene.uiElements[1].updateText("You Win!")
+                    MAIN.scene.uiElements[1].setColor(0,0,0)
                     if this.deathsThisLevel == 0
                         this.gameManager.starCount = this.gameManager.starCount + 1
-                        MAIN.scene.textBoxes[2].updateText(string(this.gameManager.starCount))
+                        MAIN.scene.uiElements[2].updateText(string(this.gameManager.starCount))
                     end
                 end
             end
@@ -130,12 +130,12 @@ function Base.getproperty(this::PlayerMovement, s::Symbol)
             if otherCollider.tag == "Coin"
                 DestroyEntity(otherCollider.parent)
                 this.coinSound.toggleSound()
-                MAIN.scene.textBoxes[1].updateText(string(parse(Int32, split(MAIN.scene.textBoxes[1].text, "/")[1]) + 1, "/", parse(Int32, split(MAIN.scene.textBoxes[1].text, "/")[2])))
+                MAIN.scene.uiElements[1].updateText(string(parse(Int32, split(MAIN.scene.uiElements[1].text, "/")[1]) + 1, "/", parse(Int32, split(MAIN.scene.uiElements[1].text, "/")[2])))
             elseif otherCollider.tag == "Star"
                 this.starSound.toggleSound()
                 DestroyEntity(otherCollider.parent)
                 this.gameManager.starCount = this.gameManager.starCount + 1
-                MAIN.scene.textBoxes[2].updateText(string(this.gameManager.starCount))
+                MAIN.scene.uiElements[2].updateText(string(this.gameManager.starCount))
             end
         end
     elseif s == :respawn
@@ -143,7 +143,7 @@ function Base.getproperty(this::PlayerMovement, s::Symbol)
             this.hurtSound.toggleSound()
             this.parent.transform.position = Vector2f(1, 4)
             this.gameManager.starCount = max(this.gameManager.starCount - 1, 0)
-            MAIN.scene.textBoxes[2].updateText(string(this.gameManager.starCount))
+            MAIN.scene.uiElements[2].updateText(string(this.gameManager.starCount))
             this.deathsThisLevel += 1
         end
     else

--- a/test/projects/ProfilingTest/Platformer/scripts/Title.jl
+++ b/test/projects/ProfilingTest/Platformer/scripts/Title.jl
@@ -19,7 +19,7 @@ end
 function Base.getproperty(this::Title, s::Symbol)
     if s == :initialize
         function()
-            this.textBox = MAIN.scene.textBoxes[1]
+            this.textBox = MAIN.scene.uiElements[1]
         end
     elseif s == :update
         function(deltaTime)

--- a/test/projects/SmokeTest/scenes/scene.json
+++ b/test/projects/SmokeTest/scenes/scene.json
@@ -4696,6 +4696,6 @@
             ]
         }
     ],
-    "TextBoxes": [
+    "UIElements": [
     ]
 }

--- a/test/projects/SmokeTest/scripts/TestScript.jl
+++ b/test/projects/SmokeTest/scripts/TestScript.jl
@@ -134,7 +134,7 @@ newEntity.shape != C_NULL && newEntity.shape !== nothing
 
                 # @testset "TextBox constructor" begin
                     newTextBox = TextBoxModule.TextBox("test", joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), 64, Math.Vector2(), "test", true, true; isWorldEntity=true)
-                    push!(MAIN.scene.textBoxes, newTextBox)
+                    push!(MAIN.scene.uiElements, newTextBox)
                     # # @test 
 
                     newTextBox != C_NULL && newTextBox !== nothing

--- a/test/projects/SmokeTest/scripts/TestScript.jl
+++ b/test/projects/SmokeTest/scripts/TestScript.jl
@@ -125,8 +125,9 @@ newEntity.shape != C_NULL && newEntity.shape !== nothing
             #@testset "UI Tests" begin
                 #@testset "ScreenButton constructor" begin
                     
-                    newScreenButton = ScreenButtonModule.ScreenButton("ButtonUp.png", "ButtonDown.png", Vector2(256, 64), Vector2(), joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), "test")
+                    newScreenButton = ScreenButtonModule.ScreenButton("Name", "ButtonUp.png", "ButtonDown.png", Vector2(256, 64), Vector2(), joinpath("FiraCode", "ttf", "FiraCode-Regular.ttf"), "test")
                     push!(MAIN.scene.screenButtons, newScreenButton)
+                    push!(MAIN.scene.uiElements, newScreenButton)
                     # # @test 
 
                     newScreenButton != C_NULL && newScreenButton !== nothing


### PR DESCRIPTION
The user can create screen buttons in the editor without text now. There also was some renaming and small bug fixes. The user can also now delete an entity in the editor with the "Delete" key.