### PR TITLE
Adding parenting in the editor with multi-select

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CImGui = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 NativeFileDialog = "e1fe445b-aa65-4df4-81c1-2041507f0fd4"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 JSON3 = "1"

--- a/src/Entity.jl
+++ b/src/Entity.jl
@@ -1,4 +1,5 @@
 module EntityModule
+    using UUIDs
     using ..JulGame.AnimationModule
     using ..JulGame.AnimatorModule
     using ..JulGame.ColliderModule
@@ -14,7 +15,7 @@ module EntityModule
 
     export Entity
     mutable struct Entity
-        id::Int32
+        id::String
         animator::Union{InternalAnimator, Ptr{Nothing}}
         collider::Union{InternalCollider, Ptr{Nothing}}
         circleCollider::Union{InternalCircleCollider, Ptr{Nothing}}
@@ -28,11 +29,11 @@ module EntityModule
         soundSource::Union{InternalSoundSource, Ptr{Nothing}}
         sprite::Union{InternalSprite, Ptr{Nothing}}
         transform::Transform
-        
-        function Entity(name::String = "New entity", transform::Transform = Transform(), scripts::Vector = [])
+
+        function Entity(name::String = "New entity", id::String = generate_uuid(), transform::Transform = Transform(), scripts::Vector = [])
             this = new()
 
-            this.id = 1
+            this.id = id
             this.name = name
             this.animator = C_NULL
             this.circleCollider = C_NULL
@@ -168,4 +169,7 @@ module EntityModule
         return this.shape
     end
 
+    function generate_uuid()
+        return string(UUIDs.uuid4())
+    end
 end

--- a/src/Entity.jl
+++ b/src/Entity.jl
@@ -20,6 +20,7 @@ module EntityModule
         circleCollider::Union{InternalCircleCollider, Ptr{Nothing}}
         isActive::Bool
         name::String
+        parent::Union{Entity, Ptr{Nothing}}
         persistentBetweenScenes::Bool
         rigidbody::Union{InternalRigidbody, Ptr{Nothing}}
         scripts::Vector{Any}
@@ -47,6 +48,7 @@ module EntityModule
             this.sprite = C_NULL
             this.persistentBetweenScenes = false
             this.rigidbody = C_NULL
+            this.parent = C_NULL
 
             return this
         end

--- a/src/SceneManagement/SceneBuilder.jl
+++ b/src/SceneManagement/SceneBuilder.jl
@@ -65,7 +65,7 @@ module SceneBuilderModule
         MAIN.globals = globals
         MAIN.level = this
         MAIN.targetFrameRate = targetFrameRate
-        scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
+        scene = deserialize_scene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
         MAIN.scene.entities = scene[1]
         MAIN.scene.uiElements = scene[2]
         if size.x < camSize.x && size.x > 0
@@ -134,7 +134,7 @@ module SceneBuilderModule
     end
 
     function change_scene(this::Scene, isUsingEditor::Bool = false)
-        scene = deserializeScene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
+        scene = deserialize_scene(joinpath(BasePath, "scenes", this.scene), isUsingEditor)
         
         # println("Changing scene to $this.scene")
         # println("Entities in main scene: ", length(MAIN.scene.entities))

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -19,8 +19,8 @@ module SceneReaderModule
         () -> (name; parameters)
     end
 
-    export deserializeScene
-    function deserializeScene(filePath, isEditor)
+    export deserialize_scene
+    function deserialize_scene(filePath, isEditor)
         try
             entitiesJson = read(filePath, String)
 
@@ -28,13 +28,14 @@ module SceneReaderModule
             entities =[]
             uiElements = []
             res = []
+            childParentDict = Dict()
     
             for entity in json.Entities
                 components = []
                 scripts = []
     
                 for component in entity.components
-                    push!(components, deserializeComponent(component, isEditor))
+                    push!(components, deserialize_component(component, isEditor))
                 end
                 
                 for script in entity.scripts
@@ -46,8 +47,10 @@ module SceneReaderModule
                     push!(scripts, scriptObject)
                 end
                 
-                newEntity = Entity(entity.name)
-                newEntity.id = entity.id
+                if haskey(entity, "parent") && entity.parent != ""
+                    childParentDict[entity.id] = entity.parent
+                end
+                newEntity = Entity(entity.name, string(entity.id))
                 newEntity.isActive = entity.isActive
                 newEntity.scripts = scripts
 
@@ -78,7 +81,21 @@ module SceneReaderModule
                 
                 push!(entities, newEntity)
             end
-            uiElements = deserializeUIElements(json.UIElements)
+
+            for entity in entities
+                if entity.parent != C_NULL
+                    if haskey(childParentDict, entity.parent.id)
+                        parent = childParentDict[entity.parent.id]
+                        for e in entities
+                            if e.id == parent
+                                entity.parent = e
+                            end
+                        end
+                    end
+                end
+            end
+
+            uiElements = deserialize_ui_elements(json.UIElements)
     
             push!(res, entities)
             push!(res, uiElements)
@@ -90,7 +107,7 @@ module SceneReaderModule
         end
     end
 
-    function deserializeUIElements(jsonUIElements)
+    function deserialize_ui_elements(jsonUIElements)
         res = []
 
         for uiElement in jsonUIElements
@@ -113,8 +130,8 @@ module SceneReaderModule
         return res
     end
 
-    export deserializeComponent
-    function deserializeComponent(component, isEditor)
+    export deserialize_component
+    function deserialize_component(component, isEditor)
         try
             if component.type == "Transform"
                 newComponent = Transform(Vector2f(component.position.x, component.position.y), Vector2f(component.scale.x, component.scale.y))

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -86,9 +86,7 @@ module SceneReaderModule
                     if haskey(childParentDict, string(entity.id))
                         parentId = childParentDict[string(entity.id)]
                         for e in entities
-                            println("Checking if $(e.id) == $parentId")
                             if string(e.id) == string(parentId)
-                                println("setting parent of $(entity.name) to $(e.name)")
                                 entity.parent = e
                             end
                         end

--- a/src/SceneManagement/SceneReader.jl
+++ b/src/SceneManagement/SceneReader.jl
@@ -48,7 +48,7 @@ module SceneReaderModule
                 end
                 
                 if haskey(entity, "parent") && entity.parent != ""
-                    childParentDict[entity.id] = entity.parent
+                    childParentDict[string(entity.id)] = entity.parent
                 end
                 newEntity = Entity(entity.name, string(entity.id))
                 newEntity.isActive = entity.isActive
@@ -83,16 +83,16 @@ module SceneReaderModule
             end
 
             for entity in entities
-                if entity.parent != C_NULL
-                    if haskey(childParentDict, entity.parent.id)
-                        parent = childParentDict[entity.parent.id]
+                    if haskey(childParentDict, string(entity.id))
+                        parentId = childParentDict[string(entity.id)]
                         for e in entities
-                            if e.id == parent
+                            println("Checking if $(e.id) == $parentId")
+                            if string(e.id) == string(parentId)
+                                println("setting parent of $(entity.name) to $(e.name)")
                                 entity.parent = e
                             end
                         end
                     end
-                end
             end
 
             uiElements = deserialize_ui_elements(json.UIElements)

--- a/src/SceneManagement/SceneWriter.jl
+++ b/src/SceneManagement/SceneWriter.jl
@@ -22,7 +22,7 @@ module SceneWriterModule
         
         count = 1
         for entity in entities
-            push!(entitiesDict, Dict("id" => count, "parent" =>  entity.parent != C_NULL ? entity.parent.id : C_NULL, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
+            push!(entitiesDict, Dict("id" => string(entity.id), "parent" =>  entity.parent != C_NULL ? entity.parent.id : C_NULL, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
             count += 1
         end
 

--- a/src/SceneManagement/SceneWriter.jl
+++ b/src/SceneManagement/SceneWriter.jl
@@ -22,7 +22,7 @@ module SceneWriterModule
         
         count = 1
         for entity in entities
-            push!(entitiesDict, Dict("id" => count, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
+            push!(entitiesDict, Dict("id" => count, "parent" =>  entity.parent != C_NULL ? entity.parent.id : C_NULL, "isActive" => entity.isActive, "name" => entity.name, "components" => serialize_entity_components([entity.animator, entity.collider, entity.circleCollider, entity.rigidbody, entity.shape, entity.soundSource, entity.sprite, entity.transform]), "scripts" => serialize_entity_scripts(entity.scripts)))
             count += 1
         end
 

--- a/src/editor/JulGameEditor/Components/ComponentInputs.jl
+++ b/src/editor/JulGameEditor/Components/ComponentInputs.jl
@@ -463,7 +463,7 @@ end
 
 function show_script_editor(entity)
     if CImGui.TreeNode("Scripts")
-        ShowHelpMarker("Add a script here to run it on the entity.")
+        show_help_marker("Add a script here to run it on the entity.")
         CImGui.Button("Add Script") && (push!(entity.scripts, scriptObj("",[])); return;)
         for i = eachindex(entity.scripts)
             if CImGui.TreeNode("Script $(i)")

--- a/src/editor/JulGameEditor/Components/ComponentInputs.jl
+++ b/src/editor/JulGameEditor/Components/ComponentInputs.jl
@@ -139,7 +139,7 @@ function show_component_field_input(component, componentField)
         @c CImGui.Checkbox("$(componentField)", &fieldValue)
         setfield!(component, componentField, fieldValue)
 
-    elseif isa(fieldValue, String)
+    elseif isa(fieldValue, String) && String(componentField) != "id"
         buf = "$(fieldValue)"*"\0"^(64)
         CImGui.InputText("$(componentField)", buf, length(buf))
         currentTextInTextBox = ""

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -186,7 +186,7 @@ module Editor
                                 hierarchyEntitySelections=fill(false, length(filteredEntities))
                             end
                             
-                            println(length(entitiesWithParents))
+                            #println(length(entitiesWithParents))
                             for n = eachindex(filteredEntities)
                                 if filteredEntities[n].parent != C_NULL
                                     continue

--- a/src/editor/JulGameEditor/Editor.jl
+++ b/src/editor/JulGameEditor/Editor.jl
@@ -186,7 +186,12 @@ module Editor
                                 hierarchyEntitySelections=fill(false, length(filteredEntities))
                             end
                             
+                            println(length(entitiesWithParents))
                             for n = eachindex(filteredEntities)
+                                if filteredEntities[n].parent != C_NULL
+                                    continue
+                                end
+
                                 CImGui.PushID(n)
 
                                 buf = "$(n): $(filteredEntities[n].name)"
@@ -228,9 +233,9 @@ module Editor
                                     payload = CImGui.AcceptDragDropPayload("Entity")
                                     if payload != C_NULL
                                         payload = unsafe_load(payload)
-                                    origin = unsafe_load(Ptr{Cint}(payload.Data))
-                                            destination = n
-                                            filteredEntities[n].parent = filteredEntities[origin]
+                                        origin = unsafe_load(Ptr{Cint}(payload.Data))
+                                        destination = n
+                                        filteredEntities[origin].parent = filteredEntities[destination]
                                         @assert payload.DataSize == sizeof(Cint)
                                     end
                                     CImGui.EndDragDropTarget()

--- a/src/editor/JulGameEditor/Utils/Utils.jl
+++ b/src/editor/JulGameEditor/Utils/Utils.jl
@@ -57,7 +57,7 @@ function ShowDrag()
     end # @cstatic
 end
 
-function ShowHelpMarker(desc)
+function show_help_marker(desc)
     CImGui.TextDisabled("(?)")
     if CImGui.IsItemHovered()
         CImGui.BeginTooltip()


### PR DESCRIPTION
The user should now be able to drag entities on to others in order to "parent" them. This is purely for editor organization, and shouldn't have any effect in the games themselves.